### PR TITLE
Increase partition count and test for swap

### DIFF
--- a/tests/disk_custom_standard_partition_ext4_postinstall.pm
+++ b/tests/disk_custom_standard_partition_ext4_postinstall.pm
@@ -4,13 +4,15 @@ use testapi;
 
 sub run {
     assert_screen "root_console";
-    my $count = 3;
+    my $count = 4;
     my $devroot = 'vda1';
     my $devboot = 'vda2';
+    my $devswap = 'vda3';
     if (get_var('OFW') || get_var('UEFI')) {
-        $count = 4; # extra boot partition (PreP or ESP)
+        $count = 5; # extra boot partition (PreP or ESP)
         $devroot = 'vda2';
         $devboot = 'vda3';
+        $devswap = 'vda4';
     }
     # check number of partitions
     script_run 'fdisk -l | grep /dev/vda'; # debug
@@ -19,6 +21,7 @@ sub run {
     script_run 'mount | grep /dev/vda'; # debug
     validate_script_output "mount | grep /dev/$devboot", sub { $_ =~ m/on \/boot type ext4/ };
     validate_script_output "mount | grep /dev/$devroot", sub { $_ =~ m/on \/ type ext4/ };
+    validate_script_output "swapon --show | grep /dev/$devswap", sub { $_ =~ m/ partition / };
 }
 
 sub test_flags {


### PR DESCRIPTION
## Description

Updates partition count in `tests/disk_custom_standard_partition_ext4_postinstall.pm` to account for Rocky default partitioning which includes `swap` partition and adds postinstall test to verify `swap` is active.

Closes #11 

## How Has This Been Tested?

- [x] POST of test for dvd-iso flavor with pass of `disk_custom_standard_partition_ext4_postinstall` test suite.

![disk_custom_standard_partition_ext4_postinstall](https://user-images.githubusercontent.com/542846/130179536-120e80ef-ae78-4ba6-b27b-623bd019c96d.png)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules