### PR TITLE
Create config.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+--- 
+blank_issues_enabled: false
+contact_links: 
+  - name: "Rocky Linux Community Support - Testing Team"
+    url: "https://chat.rockylinux.org/rocky-linux/channels/testing"
+    about: "Please ask and answer questions about openQA for Rocky Linux here.


### PR DESCRIPTION
Per Github [documentation](https://docs.github.com/articles/configuring-issue-templates-for-your-repository#configuring-the-template-chooser) add `config.yaml` for template chooser.

This is an attempt to resolve the loss of the Issue template chooser.