### PR TITLE
add addition data collection

### DIFF
--- a/tests/_collect_data.pm
+++ b/tests/_collect_data.pm
@@ -10,6 +10,9 @@ sub run {
     unless (get_var("CANNED")) {
         assert_script_run 'rpm -qa --queryformat "%{NAME}\n" | sort -u > /var/tmp/rpms.log';
         upload_logs '/var/tmp/rpms.log';
+        # installed packages as CSV with separated NEVRA
+        assert_script_run 'rpm -qa --queryformat="%{NAME},%{EPOCH},%{VERSION},%{RELEASE},%{ARCH}\n" | sort > /var/tmp/rpms.nevra.csv';
+        upload_logs '/var/tmp/rpms.nevra.csv';
     }
     assert_script_run 'free > /var/tmp/free.log';
     upload_logs '/var/tmp/free.log';
@@ -17,6 +20,26 @@ sub run {
     upload_logs '/var/tmp/df.log';
     assert_script_run 'systemctl -t service --no-pager --no-legend | grep -o "[[:graph:]]*\.service" > /var/tmp/services.log';
     upload_logs '/var/tmp/services.log';
+
+    # Record default (or non-default) partitioning
+    assert_script_run 'lsblk > /var/tmp/lsblk.log';
+    upload_logs '/var/tmp/lsblk.log';
+
+    # Record selected group
+    assert_script_run 'dnf group list --verbose > /var/tmp/dnf-group-list.log';
+    upload_logs '/var/tmp/dnf-group-list.log';
+
+    # Collect all combinations of modules
+    assert_script_run 'dnf module list --enabled > /var/tmp/dnf-module-list-enabled.log';
+    upload_logs '/var/tmp/dnf-module-list-enabled.log';
+    assert_script_run 'dnf module list --disabled > /var/tmp/dnf-module-list-disabled.log';
+    upload_logs '/var/tmp/dnf-module-list-disabled.log';
+    assert_script_run 'dnf module list --installed > /var/tmp/dnf-module-list-installed.log';
+    upload_logs '/var/tmp/dnf-module-list-installed.log';
+    assert_script_run 'dnf module list --available > /var/tmp/dnf-module-list-available.log';
+    upload_logs '/var/tmp/dnf-module-list-available.log';
+    assert_script_run 'dnf module list --all > /var/tmp/dnf-module-list-all.log';
+    upload_logs '/var/tmp/dnf-module-list-all.log';
 }
 
 sub test_flags {


### PR DESCRIPTION
# Description

Adds additional data collection tasks to `_collect_data.pl` test.

Fixes #30 

# How Has This Been Tested?

Reran existing test `install_minimal@64bit` for `rocky-8.4-minimal-iso.x86_64` originally submitted as part of ansible automation as...

**tasks/openqa.yml**
```yaml
- name: POST a job
  command: |
    openqa-cli api -X POST isos \
      ISO=Rocky-{{ rocky_version }}-{{ rocky_arch }}-minimal.iso \
      ARCH={{ rocky_arch }} \
      DISTRI=rocky \
      FLAVOR=minimal-iso \
      VERSION={{ rocky_version }} \
      BUILD="{{ '%Y%m%d.%H%M%S' | strftime }}.0"
  changed_when: "1 != 1"
```

Test completed to 100% and additional data collected was uploaded to the openQA server.

<img width="803" alt="issue_30_test_success" src="https://user-images.githubusercontent.com/542846/132558762-ec4aea95-3d51-4524-a237-f6a536fca6a7.png">

**sample output - `_collect_data-lsblk.log`**
```
NAME        MAJ:MIN RM  SIZE RO TYPE MOUNTPOINT
sr0          11:0    1  1.9G  0 rom  
vda         252:0    0   10G  0 disk 
├─vda1      252:1    0    1G  0 part /boot
└─vda2      252:2    0    9G  0 part 
  ├─rl-root 253:0    0    8G  0 lvm  /
  └─rl-swap 253:1    0    1G  0 lvm  [SWAP]
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules