### PR TITLE
Fixes needle with invalid JSON and adds pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-json
+    -   id: check-yaml
+    -   id: check-added-large-files

--- a/needles/anaconda/partitioning/rocky-fs_ext4_preselected-20210812.json
+++ b/needles/anaconda/partitioning/rocky-fs_ext4_preselected-20210812.json
@@ -12,6 +12,6 @@
   "tags": [
     "anaconda_part_fs",
     "anaconda_part_fs_ext4_selected",
-    "ENV-DISTRI-rocky",
+    "ENV-DISTRI-rocky"
   ]
 }


### PR DESCRIPTION
## Description

This PR adds repairs a needle with invalid JSON and fixes #58. In addition, it adds `pre-commit` configuration to prevent future errors similar in nature.

*NOTE: The `pre-commit` configuration includes the `end-of-file-fixer` hook which will make sure all files end with a newline character. openQA needle editor does not put a newline at the end of needle JSON files. All new needles will be modified to include a newline at the end automatically.*

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules