### PR TITLE
Fixes multiple tests in regard of the PACKAGE_SETs `graphical-server` and `workstation`

### DIFF
--- a/RESULTS.md
+++ b/RESULTS.md
@@ -16,47 +16,74 @@ Product test commands
 ---
 
 rocky-boot-iso-x86_64-*
-```
-sudo openqa-cli api -X POST isos \
+```sh
+openqa-cli api -X POST isos \
   ISO=Rocky-8.4-x86_64-boot.iso \
-  DISTRI=rocky \
-  VERSION=8.4 \
-  FLAVOR=boot-iso \
   ARCH=x86_64 \
+  DISTRI=rocky \
+  FLAVOR=boot-iso \
+  VERSION=8.4 \
   BUILD="-boot-iso-$(date +%Y%m%d.%H%M%S).0"
 ```
 
 rocky-minimal-iso-x86_64-*
-```
-sudo openqa-cli api -X POST isos \
+```sh
+openqa-cli api -X POST isos \
   ISO=Rocky-8.4-x86_64-minimal.iso \
-  DISTRI=rocky \
-  VERSION=8.4 \
-  FLAVOR=minimal-iso \
   ARCH=x86_64 \
+  DISTRI=rocky \
+  FLAVOR=minimal-iso \
+  VERSION=8.4 \
   BUILD="-minimal-iso-$(date +%Y%m%d.%H%M%S).0"
 ```
 
 rocky-dvd-iso-x86_64-*
-```
-sudo openqa-cli api -X POST isos \
+```sh
+openqa-cli api -X POST isos \
   ISO=Rocky-8.4-x86_64-dvd1.iso \
-  DISTRI=rocky \
-  VERSION=8.4 \
+  ARCH=x86_64 DISTRI=rocky \
   FLAVOR=dvd-iso \
+  PACKAGE_SET=minimal \
+  VERSION=8.4 \
+  BUILD="-minimal-$(date +%Y%m%d.%H%M%S).0"
+
+openqa-cli api -X POST isos \
+  ISO=Rocky-8.4-x86_64-dvd1.iso \
   ARCH=x86_64 \
-  BUILD="-dvd-iso-$(date +%Y%m%d.%H%M%S).0"
+  DISTRI=rocky \
+  FLAVOR=dvd-iso \
+  PACKAGE_SET=server \
+  VERSION=8.4 \
+  BUILD="-server-$(date +%Y%m%d.%H%M%S).0"
+
+openqa-cli api -X POST isos \
+  ISO=Rocky-8.4-x86_64-dvd1.iso \
+  ARCH=x86_64 \
+  DISTRI=rocky \
+  FLAVOR=dvd-iso \
+  PACKAGE_SET=graphical-server \
+  DESKTOP=gnome \
+  VERSION=8.4 \
+  BUILD="-graphical-server-$(date +%Y%m%d.%H%M%S).0"
+
+openqa-cli api -X POST isos \
+  ISO=Rocky-8.4-x86_64-dvd1.iso \
+  ARCH=x86_64 \
+  DISTRI=rocky \
+  FLAVOR=dvd-iso \
+  PACKAGE_SET=workstation \
+  DESKTOP=gnome \
+  VERSION=8.4 \
+  BUILD="-workstation-$(date +%Y%m%d.%H%M%S).0"
 ```
 
 rocky-universal-x86_64-*
-```
-sudo openqa-cli api -X POST isos \
+```sh
+openqa-cli api -X POST isos \
   ISO=Rocky-8.4-x86_64-dvd1.iso \
-  DISTRI=rocky \
-  VERSION=8.4 \
-  FLAVOR=universal \
   ARCH=x86_64 \
+  DISTRI=rocky \
+  FLAVOR=universal \
+  VERSION=8.4 \
   BUILD="-universal-$(date +%Y%m%d.%H%M%S).0"
 ```
-
-

--- a/templates.fif.json
+++ b/templates.fif.json
@@ -562,6 +562,7 @@
                 "rocky-dvd-iso-x86_64-*-uefi": 31
             },
             "settings": {
+                "HDDSIZEGB": "15",
                 "PARTITIONING": "custom_standard_partition_ext4",
                 "ROOT_PASSWORD": "weakpassword"
             }

--- a/tests/_graphical_wait_login.pm
+++ b/tests/_graphical_wait_login.pm
@@ -39,18 +39,20 @@ sub run {
     # install, which transitions straight from g-i-s to logged-in
     # desktop
     unless (get_var("DESKTOP") eq 'gnome' && get_var("INSTALL_NO_USER")) {
-        # for Rocky Linux here happens to be a license acceptance screen
-        # the initial appearance can sometimes take really long
-        assert_screen "gdm_initial_setup_license", 120;
-        assert_and_click "gdm_initial_setup_license";
-        # Make sure the card has fully lifted until clicking on the buttons
-        wait_still_screen 5, 30;
-        assert_and_click "gdm_initial_setup_licence_accept";
-        assert_and_click "gdm_spoke_done";
-        # As well as coming back
-        wait_still_screen 5, 30;
-        assert_screen "gdm_initial_setup_license_accepted";
-        assert_and_click "gdm_initial_setup_spoke_forward";
+        unless (get_var("HDD_1") && !(get_var("PARTITIONING") eq "custom_resize_lvm")) {
+            # for Rocky Linux here happens to be a license acceptance screen
+            # the initial appearance can sometimes take really long
+            assert_screen "gdm_initial_setup_license", 120;
+            assert_and_click "gdm_initial_setup_license";
+            # Make sure the card has fully lifted until clicking on the buttons
+            wait_still_screen 5, 30;
+            assert_and_click "gdm_initial_setup_licence_accept";
+            assert_and_click "gdm_spoke_done";
+            # As well as coming back
+            wait_still_screen 5, 30;
+            assert_screen "gdm_initial_setup_license_accepted";
+            assert_and_click "gdm_initial_setup_spoke_forward";
+        }
 
         boot_to_login_screen(timeout => $wait_time);
         # if USER_LOGIN is set to string 'false', we're done here

--- a/tests/disk_custom_lvm_ext4_postinstall.pm
+++ b/tests/disk_custom_lvm_ext4_postinstall.pm
@@ -1,8 +1,13 @@
 use base "installedtest";
 use strict;
 use testapi;
+use utils;
 
 sub run {
+    my $self = shift;
+    unless (check_screen "root_console", 0) {
+        $self->root_console(tty=>4);
+    }
     assert_screen "root_console";
     my $devboot = 'vda1';
 

--- a/tests/disk_custom_lvmthin_postinstall.pm
+++ b/tests/disk_custom_lvmthin_postinstall.pm
@@ -1,8 +1,13 @@
 use base "installedtest";
 use strict;
 use testapi;
+use utils;
 
 sub run {
+    my $self = shift;
+    unless (check_screen "root_console", 0) {
+        $self->root_console(tty=>4);
+    }
     assert_screen "root_console";
     # check that lvmthinpool is present:
     # http://atodorov.org/blog/2015/04/14/how-to-find-if-lvm-volume-is-thinly-provisioned/

--- a/tests/disk_custom_software_raid_postinstall.pm
+++ b/tests/disk_custom_software_raid_postinstall.pm
@@ -1,8 +1,13 @@
 use base "installedtest";
 use strict;
 use testapi;
+use utils;
 
 sub run {
+    my $self = shift;
+    unless (check_screen "root_console", 0) {
+        $self->root_console(tty=>4);
+    }
     assert_screen "root_console";
     # check that RAID is used
     assert_script_run "cat /proc/mdstat | grep 'Personalities : \\\[raid1\\\]'";

--- a/tests/disk_custom_standard_partition_ext4_postinstall.pm
+++ b/tests/disk_custom_standard_partition_ext4_postinstall.pm
@@ -1,8 +1,13 @@
 use base "installedtest";
 use strict;
 use testapi;
+use utils;
 
 sub run {
+    my $self = shift;
+    unless (check_screen "root_console", 0) {
+        $self->root_console(tty=>4);
+    }
     assert_screen "root_console";
     my $count = 4;
     my $devroot = 'vda1';


### PR DESCRIPTION
## Description

This PR fixes multiple cases of the beforementioned `graphical-server` and `workstation` PACKAGE_SETs.
It also includes a new set of expample test commands to mention all currently available cases.

This PR also fixes #60 and will automatically close when this is resolved.

## How Has This Been Tested?

```sh
openqa-cli api -X POST isos ISO=Rocky-8.4-x86_64-dvd1.iso ARCH=x86_64 DISTRI=rocky FLAVOR=dvd-iso PACKAGE_SET=graphical-server VERSION=8.4 BUILD=-graphical-server-$(date +%Y%m%d.%H%M%S).0 DESKTOP=gnome
openqa-cli api -X POST isos ISO=Rocky-8.4-x86_64-dvd1.iso ARCH=x86_64 DISTRI=rocky FLAVOR=dvd-iso PACKAGE_SET=workstation VERSION=8.4 BUILD=-workstation-$(date +%Y%m%d.%H%M%S).0 DESKTOP=gnome
```

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules (Please merge PR #56 before this one)

Please note this PR does not fully fix the 2 PACKAGE_SETs!
these are the current states:
Workstation:
![image](https://user-images.githubusercontent.com/42647570/141159086-a387c883-3e54-467e-894a-a76957162b5a.png)
Graphical Server:
![image](https://user-images.githubusercontent.com/42647570/141159165-db07a9c5-6cf7-42dd-813c-a6c2aac5703f.png)
