### PR TITLE
Correct needle to properly detect network connected

### DIFF
--- a/needles/anaconda/network/rocky-anaconda_network_connected-20211121.json
+++ b/needles/anaconda/network/rocky-anaconda_network_connected-20211121.json
@@ -3,7 +3,7 @@
     {
       "height": 38,
       "type": "match",
-      "width": 42,
+      "width": 74,
       "xpos": 719,
       "ypos": 339
     }


### PR DESCRIPTION
### Description

This PR fixes #68 to allow needle match when network is connected before entering Network spoke and when network is not required for install for `minimal-iso` and `dvd-iso` flavors.

Before this change needle would also match if network was not connected but _not_ required (ie. `minimal-iso` or `dvd-iso`).

_NOTE: Perhaps the smallest fix yet... 32 pixels... but **hours** wasted._

### How Has This Been Tested?

```sh
$ openqa-cli api -X POST isos \
    ISO=Rocky-8.5-x86_64-minimal.iso \
    ARCH=x86_64 DISTRI=rocky \
    FLAVOR=minimal-iso \
    VERSION=8.5 \
    BUILD=$(date +%Y%m%d.%H%M%S).0 \
    GRUB="ip=dhcp"
    
$ openqa-cli api -X POST isos \
    ISO=Rocky-8.5-x86_64-minimal.iso \
    ARCH=x86_64 \
    DISTRI=rocky \
    FLAVOR=minimal-iso \
    VERSION=8.5 \
    BUILD=$(date +%Y%m%d.%H%M%S).0
    
$ openqa-cli api -X POST isos \
    ISO=Rocky-8.5-x86_64-dvd1.iso \
    ARCH=x86_64 \
    DISTRI=rocky \
    FLAVOR=dvd-iso \
    VERSION=8.5 \
    BUILD=$(date +%Y%m%d.%H%M%S).0 \
    GRUB="ip=dhcp" \
    TEST=install_lvm_ext4 \
    PACKAGE_SET=server
    
$ openqa-cli api -X POST isos \
    ISO=Rocky-8.5-x86_64-dvd1.iso \
    ARCH=x86_64 \
    DISTRI=rocky \
    FLAVOR=dvd-iso \
    VERSION=8.5 \
    BUILD=$(date +%Y%m%d.%H%M%S).0 \
    TEST=install_lvm_ext4 \
    PACKAGE_SET=server
```

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation where required
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules