### PR TITLE
Extend timeouts for Rocky

### DIFF
--- a/tests/_do_install_and_reboot.pm
+++ b/tests/_do_install_and_reboot.pm
@@ -112,8 +112,8 @@ sub run {
     # we're on a debug kernel, debug kernel installs are really slow.
     my $timeout = 1800;
     my $version = lc(get_var('VERSION'));
-    if ($version eq "rawhide") {
-        $timeout = 2400;
+    if ($version eq "rawhide" || lc(get_var('DISTRI')) eq "rocky") {
+        $timeout = 4800;
     }
     # workstation especially has an unfortunate habit of kicking in
     # the screensaver during install...

--- a/tests/install_text.pm
+++ b/tests/install_text.pm
@@ -141,7 +141,7 @@ sub run {
     # begin installation
     console_type_wait("b\n");
 
-    # When simulated crash is planned, then proceed with the crash routines and finish, 
+    # When simulated crash is planned, then proceed with the crash routines and finish,
     # otherwise proceed normally and do
     if (get_var("CRASH_REPORT")) {
         crash_anaconda_text;
@@ -153,7 +153,7 @@ sub run {
     # we're on a debug kernel, debug kernel installs are really slow.
     my $timeout = 1800;
     if (lc(get_var('VERSION')) eq "rawhide" || lc(get_var('DISTRI')) eq "rocky") {
-        $timeout = 2400;
+        $timeout = 4800;
     }
 
     if (testapi::is_serial_terminal) {


### PR DESCRIPTION
## Description

This PR extends timeouts for `_do_install_and_reboot` and `install_text` tests allowing for long duration installs on slow openQA dev systems.

This PR also fixes #70 and will automatically close when this is resolved.

## How Has This Been Tested?

```sh
openqa-cli api -X POST isos ISO=Rocky-8.4-x86_64-dvd1.iso ARCH=x86_64 DISTRI=rocky FLAVOR=dvd-iso PACKAGE_SET=graphical-server VERSION=8.4 BUILD=-graphical-server-$(date +%Y%m%d.%H%M%S).0 DESKTOP=gnome
openqa-cli api -X POST isos ISO=Rocky-8.4-x86_64-dvd1.iso ARCH=x86_64 DISTRI=rocky FLAVOR=dvd-iso PACKAGE_SET=workstation VERSION=8.4 BUILD=-workstation-$(date +%Y%m%d.%H%M%S).0 DESKTOP=gnome
```

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules (Please merge PR #56 before this one)