### PR TITLE
[8.6 Release Issues] Test Suite: Increase default HDDSIZEGB for all test suites

### DIFF
--- a/templates.fif.json
+++ b/templates.fif.json
@@ -358,7 +358,6 @@
             "settings": {
                 "DESKTOP": "gnome",
                 "ENCRYPT_PASSWORD": "weakpassword",
-                "HDDSIZEGB": "15",
                 "LANGUAGE": "arabic",
                 "PACKAGE_SET": "workstation",
                 "POSTINSTALL": "_console_login",
@@ -377,7 +376,6 @@
             "settings": {
                 "DESKTOP": "gnome",
                 "ENCRYPT_PASSWORD": "weakpassword",
-                "HDDSIZEGB": "15",
                 "INPUT_METHOD": "1",
                 "LANGUAGE": "japanese",
                 "PACKAGE_SET": "workstation",
@@ -444,7 +442,6 @@
             "settings": {
                 "DESKTOP": "gnome",
                 "ENCRYPT_PASSWORD": "weakpassword",
-                "HDDSIZEGB": "15",
                 "LANGUAGE": "russian",
                 "PACKAGE_SET": "workstation",
                 "POSTINSTALL": "_console_login",
@@ -465,7 +462,6 @@
             },
             "settings": {
                 "DESKTOP": "gnome",
-                "HDDSIZEGB": "15",
                 "PACKAGE_SET": "default",
                 "POSTINSTALL": "_collect_data"
             }
@@ -534,7 +530,6 @@
             "settings": {
                 "DESKTOP": "gnome",
                 "ENCRYPT_PASSWORD": "weakpassword",
-                "HDDSIZEGB": "15",
                 "LANGUAGE": "french",
                 "NO_UEFI_POST": "1",
                 "PACKAGE_SET": "workstation",
@@ -563,7 +558,6 @@
                 "rocky-dvd-iso-x86_64-*-uefi": 41
             },
             "settings": {
-                "HDDSIZEGB": "15",
                 "PARTITIONING": "custom_lvm_ext4",
                 "ROOT_PASSWORD": "weakpassword",
                 "STORE_HDD_1": "disk_%FLAVOR%_%MACHINE%.qcow2"
@@ -576,7 +570,6 @@
                 "rocky-dvd-iso-x86_64-*-uefi": 31
             },
             "settings": {
-                "HDDSIZEGB": "15",
                 "PARTITIONING": "custom_standard_partition_ext4",
                 "ROOT_PASSWORD": "weakpassword"
             }
@@ -665,7 +658,6 @@
             "settings": {
                 "DESKTOP": "gnome",
                 "ENCRYPT_PASSWORD": "weakpassword",
-                "HDDSIZEGB": "15",
                 "PACKAGE_SET": "graphical-server",
                 "POSTINSTALL": "_console_login",
                 "ROOT_PASSWORD": "weakpassword",
@@ -682,7 +674,6 @@
             "settings": {
                 "DESKTOP": "gnome",
                 "ENCRYPT_PASSWORD": "weakpassword",
-                "HDDSIZEGB": "15",
                 "PACKAGE_SET": "workstation",
                 "POSTINSTALL": "_console_login",
                 "ROOT_PASSWORD": "weakpassword",

--- a/templates.fif.json
+++ b/templates.fif.json
@@ -57,6 +57,7 @@
             "settings": {
                 "GRUB": "ip=dhcp",
                 "+QEMURAM": 3072,
+                "HDDSIZEGB": "15",
                 "TEST_TARGET": "ISO"
             },
             "version": "*"
@@ -68,6 +69,7 @@
             "settings": {
                 "GRUB": "ip=dhcp",
                 "+QEMURAM": 3072,
+                "HDDSIZEGB": "15",
                 "TEST_TARGET": "ISO"
             },
             "version": "*"
@@ -79,6 +81,7 @@
             "settings": {
                 "+QEMURAM": 3072,
                 "DEPLOY_UPLOAD_TEST": "install_minimal_upload",
+                "HDDSIZEGB": "15",
                 "TEST_TARGET": "ISO"
             },
             "version": "*"
@@ -90,6 +93,7 @@
             "settings": {
                 "+QEMURAM": 3072,
                 "DEPLOY_UPLOAD_TEST": "install_minimal_upload",
+                "HDDSIZEGB": "15",
                 "TEST_TARGET": "ISO"
             },
             "version": "*"
@@ -100,6 +104,7 @@
             "flavor": "dvd-iso",
             "settings": {
                 "DEPLOY_UPLOAD_TEST": "install_default_upload",
+                "HDDSIZEGB": "15",
                 "TEST_TARGET": "ISO"
             },
             "version": "*"
@@ -110,6 +115,7 @@
             "flavor": "dvd-iso",
             "settings": {
                 "DEPLOY_UPLOAD_TEST": "install_default_upload",
+                "HDDSIZEGB": "15",
                 "TEST_TARGET": "ISO"
             },
             "version": "*"
@@ -119,6 +125,7 @@
             "distri": "rocky",
             "flavor": "package-set",
             "settings": {
+                "HDDSIZEGB": "15",
                 "TEST_TARGET": "ISO"
             },
             "version": "*"
@@ -128,6 +135,7 @@
             "distri": "rocky",
             "flavor": "package-set",
             "settings": {
+                "HDDSIZEGB": "15",
                 "TEST_TARGET": "ISO"
             },
             "version": "*"
@@ -137,6 +145,7 @@
             "distri": "rocky",
             "flavor": "universal",
             "settings": {
+                "HDDSIZEGB": "15",
                 "TEST_TARGET": "ISO"
             },
             "version": "*"
@@ -146,6 +155,7 @@
             "distri": "rocky",
             "flavor": "universal",
             "settings": {
+                "HDDSIZEGB": "15",
                 "TEST_TARGET": "ISO"
             },
             "version": "*"

--- a/templates.fif.json
+++ b/templates.fif.json
@@ -519,6 +519,7 @@
             "settings": {
                 "HDDMODEL": "ide-hd",
                 "HDD_1": "disk_full_mbr.img",
+                "HDDSIZEGB": "20",
                 "PARTITIONING": "guided_delete_all"
             }
         },
@@ -819,6 +820,7 @@
             },
             "settings": {
                 "HDD_1": "disk_freespace_%PART_TABLE_TYPE%.img",
+                "HDDSIZEGB": "20",
                 "PARTITIONING": "guided_free_space",
                 "ROOT_PASSWORD": "weakpassword"
             }


### PR DESCRIPTION
# Description

Sets the default `HDDSIZEGB` for all tests to 15. This also removes those settings from specific test suites where they were previously defined.

Fixes #83 when merged.

# How Has This Been Tested?

```
openqa-cli api -X POST isos ISO=Rocky-8.6-x86_64-dvd1.iso ARCH=x86_64 DISTRI=rocky FLAVOR=dvd-iso VERSION=8.6 BUILD=8.6_dvd-iso_$(date +%Y%m%d.%H%M%S).0 TEST=install_custom_gui_lvm_ext4 PACKAGE_SET=graphical-server
```
This test suite should pass `_do_install_and_reboot` at a minimum.
Note: PACKAGE_SET graphical-server will fail on `_console_wait_login` with the issue in #81.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
