### PR TITLE
[8.6 Release Issues] Test Suite: install_delete_partial and install_custom_gui_lvm_ext4 on rocky 8.6 x86_64

### DIFF
--- a/templates.fif.json
+++ b/templates.fif.json
@@ -394,6 +394,7 @@
             },
             "settings": {
                 "PARTITIONING": "custom_gui_lvm_ext4",
+                "HDDSIZEGB": "15",
                 "POSTINSTALL": "disk_custom_lvm_ext4_postinstall",
                 "ROOT_PASSWORD": "weakpassword"
             }

--- a/tests/disk_guided_delete_partial.pm
+++ b/tests/disk_guided_delete_partial.pm
@@ -18,6 +18,7 @@ sub run {
 
     assert_and_click "anaconda_install_destination_reclaim_space_delete_btn";
 
+    # If this fails with a disabled button, we didn't reclaim enough space to perform installation
     assert_and_click "anaconda_install_destination_reclaim_space_btn";
 
     # Anaconda hub


### PR DESCRIPTION
# Description

Running openQA test suite `install_delete_partial` as below throws `Test died: no candidate needle with tag(s) 'anaconda_install_destination_reclaim_space_btn' matched` at module `disk_guided_delete_partial`.

At this stage, the "Reclaim Space" button in the lower right corner of the dialog is disabled, causing the needle match to fail. Further testing determined that the "Reclaim Space" button becomes enabled when enough space will be reclaimed to perform the installation. 

# Dependencies
This PR has a dependency on [createhdds:#4](https://github.com/rocky-linux/createhdds/pull/4), which must be merged. Then the `disk_full_*` images must be regenerated by running:

    ./createhdds.py full

Fixes #80 when merged and all dependencies are met.

# How Has This Been Tested?

```
openqa-cli api -X POST isos ISO=Rocky-8.6-x86_64-dvd1.iso ARCH=x86_64 DISTRI=rocky FLAVOR=dvd-iso VERSION=8.6 BUILD=8.6_dvd-iso_$(date +%Y%m%d.%H%M%S).0 TEST=install_custom_gui_lvm_ext4
openqa-cli api -X POST isos ISO=Rocky-8.6-x86_64-dvd1.iso ARCH=x86_64 DISTRI=rocky FLAVOR=universal VERSION=8.6 BUILD=8.6_universal_$(date +%Y%m%d.%H%M%S).0 TEST=install_delete_partial
```

All tests must pass `_do_install_and_reboot`.
NOTE: These tests will fail at `_console_wait_login` with the issue in #81.

# Additional testing notes
The dialog shows that 5GB will be reclaimed by the steps taken to that point in the test, but installation requires around 9GB. Do we need to reclaim enough space for installation in order to enable that button?
_Yes, the button is enabled when enough space to install is reclaimed._

Just adding HDDSIZEGB=20 to `templates.fif.json` did not increase volume size shown in the dialog. Do we need to recreate the img file?
_Yes, recreating the img file using createhdds.py against a larger size in hdds.json resolved this error._

The Reclaim Space dialog claimed 9.06GB was required to perform installation, and after doubling the size of disk_full_XXX.img we got past the Reclaim Space dialog. However, `_do_install_and_reboot` failed to install citing not enough disk space. Not sure if this is a problem but if so, it is probably outside the scope of this particular issue. We should make a decision about whether to address this later.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules