### PR TITLE
[8.6 Release Issues]: Update img url

### DIFF
--- a/templates.fif.json
+++ b/templates.fif.json
@@ -761,7 +761,7 @@
             },
             "settings": {
                 "CDMODEL": "scsi-cd",
-                "GRUB": "inst.updates=https://rockypeople.org/groups/qa/updates/updates-openqa.img",
+                "GRUB": "inst.updates=https://fedorapeople.org/groups/qa/updates/updates-openqa.img",
                 "HDDMODEL": "scsi-hd",
                 "SCSICONTROLLER": "virtio-scsi-pci",
                 "TEST_UPDATES": "1"


### PR DESCRIPTION
This PR fixes the URL for the updates.img file used in `install_scsi_updates_img`. Previously it was pointing to a domain that does not resolve.