### PR TITLE
Fix leftbar needle

### DIFF
--- a/needles/anaconda/identification/rocky-leftbar_generic-20220706.json
+++ b/needles/anaconda/identification/rocky-leftbar_generic-20220706.json
@@ -11,7 +11,6 @@
   "properties": [],
   "tags": [
     "ENV-DISTRI-rocky",
-    "LANGUAGE-english",
     "leftbar_generic"
   ]
 }


### PR DESCRIPTION
# Description

The leftbar_generic needle should not have a LANGUAGE tag. This PR removes it.

# How Has This Been Tested?

```
openqa-cli api -X POST isos ISO=Rocky-9.0-x86_64-dvd.iso ARCH=x86_64 DISTRI=rocky FLAVOR=universal VERSION=9.0 BUILD=-universal-$(git branch --show-current)-$(date +%Y%m%d.%H%M%S).0 TEST=install_arabic_language
```
This will succeed up until the post-install Welcome Tour, where it will fail.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
