### PR TITLE
Readjust needle area to work for other language tests

### DIFF
--- a/needles/anaconda/identification/rocky-topbar_generic-20220706.json
+++ b/needles/anaconda/identification/rocky-topbar_generic-20220706.json
@@ -1,9 +1,9 @@
 {
   "area": [
     {
-      "width": 531,
+      "width": 480,
       "height": 32,
-      "xpos": 237,
+      "xpos": 240,
       "ypos": 31,
       "type": "match"
     }


### PR DESCRIPTION
# Description

The topbar_generic needle, had a too big match box, and due to that didn't match for japanese and french,
this PR shrinks the size.

# How Has This Been Tested?

```
openqa-cli api -X POST isos ISO=Rocky-9.0-x86_64-dvd.iso ARCH=x86_64 DISTRI=rocky FLAVOR=dvd-iso PACKAGE_SET=workstation VERSION=9.0 BUILD=-workstation-$(git branch --show-current)-$(date +%Y%m%d.%H%M%S).0 TEST=install_package_set_virtualization-host
openqa-cli api -X POST isos ISO=Rocky-9.0-x86_64-dvd.iso ARCH=x86_64 DISTRI=rocky FLAVOR=universal VERSION=9.0 BUILD=-universal-$(git branch --show-current)-$(date +%Y%m%d.%H%M%S).0 TEST=install_arabic_language
openqa-cli api -X POST isos ISO=Rocky-9.0-x86_64-dvd.iso ARCH=x86_64 DISTRI=rocky FLAVOR=universal VERSION=9.0 BUILD=-universal-$(git branch --show-current)-$(date +%Y%m%d.%H%M%S).0 TEST=install_asian_language
openqa-cli api -X POST isos ISO=Rocky-9.0-x86_64-dvd.iso ARCH=x86_64 DISTRI=rocky FLAVOR=universal VERSION=9.0 BUILD=-universal-$(git branch --show-current)-$(date +%Y%m%d.%H%M%S).0 TEST=install_cyrillic_language
openqa-cli api -X POST isos ISO=Rocky-9.0-x86_64-dvd.iso ARCH=x86_64 DISTRI=rocky FLAVOR=universal VERSION=9.0 BUILD=-universal-$(git branch --show-current)-$(date +%Y%m%d.%H%M%S).0 TEST=install_european_language
```
This will succeed up until the post-install Welcome Tour, where it will fail.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
