### PR TITLE
Switch to ide-hd as ide-drive got removed

### DIFF
--- a/templates.fif.json
+++ b/templates.fif.json
@@ -760,7 +760,7 @@
             },
             "settings": {
                 "ATACONTROLLER": "ich9-ahci",
-                "HDDMODEL": "ide-drive,bus=ahci0.0"
+                "HDDMODEL": "ide-hd,bus=ahci0.0"
             }
         },
         "install_scsi_updates_img": {


### PR DESCRIPTION
# Description

This switches to `ide-hd` which kind of replaced `ide-drive`.

Fixes #123 

# How Has This Been Tested?

```
openqa-cli api -X POST isos ISO=Rocky-9.0-x86_64-dvd.iso ARCH=x86_64 DISTRI=rocky FLAVOR=universal VERSION=9.0 BUILD=-universal-$(git branch --show-current)-$(date +%Y%m%d.%H%M%S).0 TEST=install_sata
```
This will succeed up until the first start as it waits for `console`, this will be fixed in a later PR

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
