### PR TITLE
Add minimal and desktop false to all incorrect tests in universal

### DIFF
--- a/templates.fif.json
+++ b/templates.fif.json
@@ -420,7 +420,9 @@
                 "NUMDISKS": "2",
                 "PARTITIONING": "custom_gui_software_raid",
                 "POSTINSTALL": "disk_custom_software_raid_postinstall",
-                "ROOT_PASSWORD": "weakpassword"
+                "ROOT_PASSWORD": "weakpassword",
+                "PACKAGE_SET": "minimal",
+                "DESKTOP": "false"
             }
         },
         "install_custom_gui_xfs": {
@@ -432,7 +434,9 @@
             "settings": {
                 "PARTITIONING": "custom_gui_xfs",
                 "POSTINSTALL": "disk_custom_xfs_postinstall",
-                "ROOT_PASSWORD": "weakpassword"
+                "ROOT_PASSWORD": "weakpassword",
+                "PACKAGE_SET": "minimal",
+                "DESKTOP": "false"
             }
         },
         "install_cyrillic_language": {
@@ -509,7 +513,9 @@
             "settings": {
                 "HDD_1": "disk_full_%PART_TABLE_TYPE%.img",
                 "PARTITIONING": "guided_delete_partial",
-                "ROOT_PASSWORD": "weakpassword"
+                "ROOT_PASSWORD": "weakpassword",
+                "PACKAGE_SET": "minimal",
+                "DESKTOP": "false"
             }
         },
         "install_delete_pata": {
@@ -522,7 +528,9 @@
                 "HDDMODEL": "ide-hd",
                 "HDD_1": "disk_full_mbr.img",
                 "HDDSIZEGB": "20",
-                "PARTITIONING": "guided_delete_all"
+                "PARTITIONING": "guided_delete_all",
+                "PACKAGE_SET": "minimal",
+                "DESKTOP": "false"
             }
         },
         "install_european_language": {
@@ -551,7 +559,9 @@
             },
             "settings": {
                 "PARTITIONING": "custom_lvmthin",
-                "ROOT_PASSWORD": "weakpassword"
+                "ROOT_PASSWORD": "weakpassword",
+                "PACKAGE_SET": "minimal",
+                "DESKTOP": "false"
             }
         },
         "install_lvm_ext4": {
@@ -596,7 +606,9 @@
                 "HDD_2": "disk_full_mbr.img",
                 "NUMDISKS": "2",
                 "PARTITIONING": "guided_multi",
-                "ROOT_PASSWORD": "weakpassword"
+                "ROOT_PASSWORD": "weakpassword",
+                "PACKAGE_SET": "minimal",
+                "DESKTOP": "false"
             }
         },
         "install_multi_empty": {
@@ -608,7 +620,9 @@
             "settings": {
                 "NUMDISKS": "2",
                 "PARTITIONING": "guided_multi_empty_all",
-                "ROOT_PASSWORD": "weakpassword"
+                "ROOT_PASSWORD": "weakpassword",
+                "PACKAGE_SET": "minimal",
+                "DESKTOP": "false"
             }
         },
         "install_with_swap": {
@@ -619,7 +633,9 @@
             },
             "settings": {
                 "PARTITIONING": "custom_with_swap",
-                "ROOT_PASSWORD": "weakpassword"
+                "ROOT_PASSWORD": "weakpassword",
+                "PACKAGE_SET": "minimal",
+                "DESKTOP": "false"
             }
         },
         "install_package_set_minimal": {
@@ -692,7 +708,9 @@
                 "rocky-universal-x86_64-*-64bit": 20
             },
             "settings": {
-                "REPOSITORY_GRAPHICAL": "%LOCATION%"
+                "REPOSITORY_GRAPHICAL": "%LOCATION%",
+                "PACKAGE_SET": "minimal",
+                "DESKTOP": "false"
             }
         },
         "install_repository_http_variation": {
@@ -701,7 +719,9 @@
                 "rocky-universal-x86_64-*-64bit": 20
             },
             "settings": {
-                "REPOSITORY_VARIATION": "%LOCATION%"
+                "REPOSITORY_VARIATION": "%LOCATION%",
+                "PACKAGE_SET": "minimal",
+                "DESKTOP": "false"
             }
         },
         "install_rescue_encrypted": {
@@ -725,7 +745,9 @@
             },
             "settings": {
                 "ATACONTROLLER": "ich9-ahci",
-                "HDDMODEL": "ide-hd,bus=ahci0.0"
+                "HDDMODEL": "ide-hd,bus=ahci0.0",
+                "PACKAGE_SET": "minimal",
+                "DESKTOP": "false"
             }
         },
         "install_scsi_updates_img": {
@@ -738,7 +760,9 @@
                 "GRUB": "inst.updates=https://fedorapeople.org/groups/qa/updates/updates-openqa.img",
                 "HDDMODEL": "scsi-hd",
                 "SCSICONTROLLER": "virtio-scsi-pci",
-                "TEST_UPDATES": "1"
+                "TEST_UPDATES": "1",
+                "PACKAGE_SET": "minimal",
+                "DESKTOP": "false"
             }
         },
         "install_serial_console": {
@@ -761,7 +785,9 @@
             "settings": {
                 "HDD_1": "disk_shrink_ext4.img",
                 "PARTITIONING": "guided_shrink",
-                "ROOT_PASSWORD": "weakpassword"
+                "ROOT_PASSWORD": "weakpassword",
+                "PACKAGE_SET": "minimal",
+                "DESKTOP": "false"
             }
         },
         "install_shrink_ntfs": {
@@ -772,7 +798,9 @@
             "settings": {
                 "HDD_1": "disk_shrink_ntfs.img",
                 "PARTITIONING": "guided_shrink",
-                "ROOT_PASSWORD": "weakpassword"
+                "ROOT_PASSWORD": "weakpassword",
+                "PACKAGE_SET": "minimal",
+                "DESKTOP": "false"
             }
         },
         "install_simple_encrypted": {
@@ -783,7 +811,9 @@
             },
             "settings": {
                 "ENCRYPT_PASSWORD": "weakpassword",
-                "STORE_HDD_1": "disk_%MACHINE%_encrypted.qcow2"
+                "STORE_HDD_1": "disk_%MACHINE%_encrypted.qcow2",
+                "PACKAGE_SET": "minimal",
+                "DESKTOP": "false"
             }
         },
         "install_simple_free_space": {
@@ -796,7 +826,9 @@
                 "HDD_1": "disk_freespace_%PART_TABLE_TYPE%.img",
                 "HDDSIZEGB": "20",
                 "PARTITIONING": "guided_free_space",
-                "ROOT_PASSWORD": "weakpassword"
+                "ROOT_PASSWORD": "weakpassword",
+                "PACKAGE_SET": "minimal",
+                "DESKTOP": "false"
             }
         },
         "install_software_raid": {
@@ -808,7 +840,9 @@
             "settings": {
                 "NUMDISKS": "2",
                 "PARTITIONING": "custom_software_raid",
-                "ROOT_PASSWORD": "weakpassword"
+                "ROOT_PASSWORD": "weakpassword",
+                "PACKAGE_SET": "minimal",
+                "DESKTOP": "false"
             }
         },
         "install_xfs": {
@@ -819,7 +853,9 @@
             },
             "settings": {
                 "PARTITIONING": "custom_xfs",
-                "ROOT_PASSWORD": "weakpassword"
+                "ROOT_PASSWORD": "weakpassword",
+                "PACKAGE_SET": "minimal",
+                "DESKTOP": "false"
             }
         },
         "memtest": {


### PR DESCRIPTION
# Description

This adds `"PACKAGE_SET": "minimal"` and `"DESKTOP": false` where needed to get the tests passing again.

Fixes #81

# How Has This Been Tested?

```
openqa-cli api -X POST isos ISO=Rocky-9.0-x86_64-dvd.iso ARCH=x86_64 DISTRI=rocky FLAVOR=universal VERSION=9.0 BUILD=-universal-$(git branch --show-current)-$(date +%Y%m%d.%H%M%S).0 DNF_CONTENTDIR=true
```
There are a lot of tests passing now! And a few new issues but mainly a lot of stuff passing! (nothing fails that passed before)

![image](https://user-images.githubusercontent.com/42647570/178162448-d15dc3bc-097b-49e9-b2ca-246b9e0c070a.png)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
