### PR TITLE
feat: set DESKTOP=false and PACKAGE_SET=minimal for dvd-iso

### DIFF
--- a/templates.fif.json
+++ b/templates.fif.json
@@ -334,6 +334,8 @@
                 "rocky-dvd-iso-x86_64-*-64bit": 40
             },
             "settings": {
+                "DESKTOP": "false",
+                "PACKAGE_SET": "minimal",
                 "PARTITIONING": "custom_resize_lvm",
                 "HDD_1": "disk_%FLAVOR%_%MACHINE%.qcow2",
                 "INSTALL": "1",
@@ -393,6 +395,8 @@
                 "rocky-dvd-iso-x86_64-*-uefi": 41
             },
             "settings": {
+                "DESKTOP": "false",
+                "PACKAGE_SET": "minimal",
                 "PARTITIONING": "custom_gui_lvm_ext4",
                 "HDDSIZEGB": "15",
                 "POSTINSTALL": "disk_custom_lvm_ext4_postinstall",
@@ -406,6 +410,8 @@
                 "rocky-dvd-iso-x86_64-*-uefi": 41
             },
             "settings": {
+                "DESKTOP": "false",
+                "PACKAGE_SET": "minimal",
                 "PARTITIONING": "custom_gui_standard_partition_ext4",
                 "ROOT_PASSWORD": "weakpassword"
             }
@@ -561,6 +567,8 @@
                 "rocky-dvd-iso-x86_64-*-uefi": 41
             },
             "settings": {
+                "DESKTOP": "false",
+                "PACKAGE_SET": "minimal",
                 "PARTITIONING": "custom_lvm_ext4",
                 "ROOT_PASSWORD": "weakpassword",
                 "STORE_HDD_1": "disk_%FLAVOR%_%MACHINE%.qcow2"


### PR DESCRIPTION
# Description
This PR adds `DESKTOP=false` and `PACKAGE_SET=minimal` for a handful of test suites that were previously failing.

Fixes #81 

# How Has This Been Tested?

```
openqa-cli api -X POST isos ISO=Rocky-9.0-x86_64-dvd.iso ARCH=x86_64 DISTRI=rocky FLAVOR=universal VERSION=9.0 BUILD=-$(date +%Y%m%d.%H%M%S).0-dvd-$(git branch --show-current)
```
The following test suites should run to completion (that were not succeeding previously):
```
install_resize_lvm
install_custom_gui_lvm_ext4
install_custom_gui_standard_partition_ext4
install_lvm_ext4
```

This PR should be merged after #125 .

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
