### PR TITLE
I once broke a bootloader needle

### DIFF
--- a/needles/console/rocky-bootloader-bios-20210805.json
+++ b/needles/console/rocky-bootloader-bios-20210805.json
@@ -2,7 +2,7 @@
   "area": [
     {
       "height": 20,
-      "ypos": 109,
+      "ypos": 214,
       "xpos": 87,
       "width": 158,
       "type": "match"


### PR DESCRIPTION
# Description

This PR fixes one of the bootloader needles, which I unfortunately broke while beside adding the actual needle I wanted to add. (#104)
This then fixes the rescue test.

# How Has This Been Tested?

```
openqa-cli api -X POST isos ISO=Rocky-9.0-x86_64-dvd.iso ARCH=x86_64 DISTRI=rocky FLAVOR=universal VERSION=9.0 BUILD=-universal-$(git branch --show-current)-$(date +%Y%m%d.%H%M%S).0 TEST=install_rescue_encrypted
```

The test should fully complete.

I'm also running this through all other tests, but doesn't look to have side effects.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
