### PR TITLE
FIF template updates for GUI installs

### DIFF
--- a/templates.fif.json
+++ b/templates.fif.json
@@ -237,6 +237,7 @@
             },
             "settings": {
                 "BOOTFROM": "c",
+                "DESKTOP": "gnome",
                 "HDD_1": "disk_%FLAVOR%_%MACHINE%.qcow2",
                 "POSTINSTALL": "base_reboot_unmount",
                 "ROOT_PASSWORD": "weakpassword",
@@ -251,6 +252,7 @@
             },
             "settings": {
                 "BOOTFROM": "c",
+                "DESKTOP": "gnome",
                 "HDD_1": "disk_%FLAVOR%_%MACHINE%.qcow2",
                 "POSTINSTALL": "base_system_logging",
                 "ROOT_PASSWORD": "weakpassword",
@@ -265,6 +267,7 @@
             },
             "settings": {
                 "BOOTFROM": "c",
+                "DESKTOP": "gnome",
                 "HDD_1": "disk_%FLAVOR%_%MACHINE%.qcow2",
                 "POSTINSTALL": "base_update_cli",
                 "ROOT_PASSWORD": "weakpassword",
@@ -279,6 +282,7 @@
             },
             "settings": {
                 "BOOTFROM": "c",
+                "DESKTOP": "gnome",
                 "HDD_1": "disk_%FLAVOR%_%MACHINE%.qcow2",
                 "POSTINSTALL": "base_package_install_remove",
                 "ROOT_PASSWORD": "weakpassword",
@@ -293,6 +297,7 @@
             },
             "settings": {
                 "BOOTFROM": "c",
+                "DESKTOP": "gnome",
                 "HDD_1": "disk_%FLAVOR%_%MACHINE%.qcow2",
                 "POSTINSTALL": "base_services_start",
                 "ROOT_PASSWORD": "weakpassword",
@@ -307,6 +312,7 @@
             },
             "settings": {
                 "BOOTFROM": "c",
+                "DESKTOP": "gnome",
                 "HDD_1": "disk_%FLAVOR%_%MACHINE%.qcow2",
                 "POSTINSTALL": "base_selinux",
                 "ROOT_PASSWORD": "weakpassword",
@@ -321,6 +327,7 @@
             },
             "settings": {
                 "BOOTFROM": "c",
+                "DESKTOP": "gnome",
                 "HDD_1": "disk_%FLAVOR%_%MACHINE%.qcow2",
                 "POSTINSTALL": "base_service_manipulation",
                 "ROOT_PASSWORD": "weakpassword",
@@ -591,6 +598,7 @@
                 "rocky-dvd-iso-x86_64-*-uefi": 31
             },
             "settings": {
+                "DESKTOP": "gnome",
                 "PARTITIONING": "custom_standard_partition_ext4",
                 "ROOT_PASSWORD": "weakpassword"
             }
@@ -882,6 +890,7 @@
             },
             "settings": {
                 "BOOTFROM": "c",
+                "DESKTOP": "gnome",
                 "HDD_1": "disk_%FLAVOR%_%MACHINE%.qcow2",
                 "POSTINSTALL": "modularity_module_list modularity_enable_disable_module modularity_install_module",
                 "ROOT_PASSWORD": "weakpassword",
@@ -923,6 +932,7 @@
             },
             "settings": {
                 "BOOTFROM": "c",
+                "DESKTOP": "gnome",
                 "HDD_1": "disk_%FLAVOR%_%MACHINE%.qcow2",
                 "POSTINSTALL": "_setup_browser server_cockpit_default",
                 "ROOT_PASSWORD": "weakpassword",
@@ -952,6 +962,7 @@
             },
             "settings": {
                 "BOOTFROM": "c",
+                "DESKTOP": "gnome",
                 "HDD_1": "disk_%FLAVOR%_%MACHINE%.qcow2",
                 "POSTINSTALL": "server_filesystem_default",
                 "ROOT_PASSWORD": "weakpassword",


### PR DESCRIPTION
# Description

Updates a number of test suites' postinstalls to use a GUI login rather than a text login.

# How Has This Been Tested?

```
# Be sure to run fifloader.py first
./fifloader.py --clean --load templates.fif.json
openqa-cli api -X POST isos ISO=Rocky-8.6-x86_64-dvd1.iso ARCH=x86_64 DISTRI=rocky FLAVOR=dvd-iso VERSION=8.6 BUILD="-$(date +%Y%m%d.%H%M%s).0-$(git branch --show-current)-dvd-8.6"
openqa-cli api -X POST isos ISO=Rocky-8.7-BETA-x86_64-dvd1.iso ARCH=x86_64 DISTRI=rocky FLAVOR=dvd-iso VERSION=8.7 BUILD="-$(date +%Y%m%d.%H%M%s).0-$(git branch --show-current)-dvd-8.7"
openqa-cli api -X POST isos ISO=Rocky-9.0-x86_64-dvd.iso ARCH=x86_64 DISTRI=rocky FLAVOR=dvd-iso VERSION=9.0 BUILD="-$(date +%Y%m%d.%H%M%s).0-$(git branch --show-current)-dvd-9.0"
```
None of these runs should show any failures at `_console_wait_login`.

Expected failures:

Test | Failure step
-- | --
install_standard_partition_ext4 | disk_custom_standard_partition_ext4_postinstall
install_standard_partition_ext4@uefi | disk_custom_standard_partition_ext4_postinstall
modularity_tests | modularity_module_list
server_cockpit_default | _setup_browser
server_filesystem_default | server_filesystem_default
release_identification | os_release (8.6 only)
release_identification | rocky_release (8.7 only)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules