### PR TITLE
9.1 wait graphical login fix - make it major version agnostic

### DIFF
--- a/tests/_graphical_wait_login.pm
+++ b/tests/_graphical_wait_login.pm
@@ -42,7 +42,7 @@ sub run {
         unless (get_var("HDD_1") && !(get_var("PARTITIONING") eq "custom_resize_lvm")) {
             # in 9.0, license screens are not shown by default
             # https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/9.0_release_notes/index#enhancement_installer-and-image-creation
-            unless ($version eq '9.0') {
+            unless (get_version_major() > 8) {
                 # for Rocky Linux here happens to be a license acceptance screen
                 # the initial appearance can sometimes take really long
                 assert_screen "gdm_initial_setup_license", 120;


### PR DESCRIPTION
# Description

This fixes the wait_graphical_login code, where we hard coded 9.0, should be the only fix needed for 9.1 so not creating a new branch for 9.1.

# How Has This Been Tested?

```bash
openqa-cli api -X POST isos ISO=Rocky-8.7-x86_64-dvd1.iso ARCH=x86_64 DISTRI=rocky FLAVOR=dvd-iso PACKAGE_SET=universal VERSION=8.7 BUILD=-8.7-universal-$(git branch --show-current)-$(date +%Y%m%d.%H%M%S).0
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules