### PR TITLE
Add support for os-autoinst/openqa updates from upstream

### DIFF
--- a/templates.fif.json
+++ b/templates.fif.json
@@ -8,7 +8,9 @@
                 "QEMUCPU": "Nehalem",
                 "QEMUCPUS": "2",
                 "QEMURAM": "2048",
-                "QEMUVGA": "virtio",
+                "QEMU_VIDEO_DEVICE": "virtio-vga",
+                "XRES": "1024",
+                "YRES": "768",
                 "QEMU_VIRTIO_RNG": "1",
                 "WORKER_CLASS": "qemu_x86_64"
             }
@@ -40,7 +42,9 @@
                 "QEMUCPU": "Nehalem",
                 "QEMUCPUS": "2",
                 "QEMURAM": "2048",
-                "QEMUVGA": "virtio",
+                "QEMU_VIDEO_DEVICE": "virtio-vga",
+                "XRES": "1024",
+                "YRES": "768",
                 "QEMU_VIRTIO_RNG": "1",
                 "UEFI": "1",
                 "UEFI_PFLASH_CODE": "/usr/share/edk2/ovmf/OVMF_CODE.fd",


### PR DESCRIPTION
## Summary
Add support for upstream updates of `os-autoinst` which, among other things, deal with change in behavior of QEMU where default EDID presents a 16:9 resolution in guests. These changes allow us to continue to use our 4:3 aspect ratio needles.

## References
- os-autoinst/os-autoinst - https://github.com/os-autoinst/os-autoinst/commit/260b01aa75c21a9099b793f0722d5b5fdce733a7
- Fedora Bodhi - https://bodhi.fedoraproject.org/updates/FEDORA-2022-0823e71823

## Testing
- enable `fedora-testing` repository in Fedora 37 openQA host and `dnf update ...` per Bodhi instructions referenced above
- update `templates.fif.json` and run `fifloader.py`
- `POST` tests for 8.7 and 9.1 for `FLAVOR=minimal-iso`
- verify tests pass

## How to exit DRAFT status
- `os-autoinst` (see Bodhi above) receives required karma and is promoted to `fedora` repository to become mainstream.