### PR TITLE
Fix `_graphical_wait_login` Test died: Settings key '_welcome_done' is invalid error.

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -685,7 +685,7 @@ sub console_initial_setup {
     type_string "c\n";
     wait_still_screen 7;
 
-    assert_screen "console_initial_setup_done", 30;
+    assert_screen "console_initial_SETUP_DONE", 30;
     type_string "c\n"; # continue
 }
 
@@ -700,7 +700,7 @@ sub handle_welcome_screen {
     else {
         record_soft_failure "Welcome tour missing";
     }
-    set_var("_welcome_done", 1);
+    set_var("_WELCOME_DONE", 1);
 }
 
 sub gnome_initial_setup {
@@ -808,7 +808,7 @@ sub gnome_initial_setup {
         handle_welcome_screen;
     }
     # don't do it again on second load
-    set_var("_setup_done", 1);
+    set_var("_SETUP_DONE", 1);
 }
 
 sub _type_user_password {

--- a/tests/_graphical_wait_login.pm
+++ b/tests/_graphical_wait_login.pm
@@ -22,7 +22,7 @@ sub run {
     }
 
     # Handle pre-login initial setup if we're doing INSTALL_NO_USER
-    if (get_var("INSTALL_NO_USER") && !get_var("_setup_done")) {
+    if (get_var("INSTALL_NO_USER") && !get_var("_SETUP_DONE")) {
         if (get_var("DESKTOP") eq 'gnome') {
             gnome_initial_setup(prelogin=>1, timeout=>$wait_time);
         }
@@ -31,7 +31,7 @@ sub run {
             # wait out animation
             wait_still_screen 3;
             assert_and_click "initialsetup_finish_configuration";
-            set_var("_setup_done", 1);
+            set_var("_SETUP_DONE", 1);
         }
         $wait_time = 300;
     }
@@ -107,20 +107,20 @@ sub run {
         if ($version_major < 9) {
             # before GNOME 40 we get a per-user version of
             # gnome-initial-setup here...
-            gnome_initial_setup() unless (get_var("_setup_done"));
+            gnome_initial_setup() unless (get_var("_SETUP_DONE"));
         }
         else {
             # ...from GNOME 40 on, we just get a "Welcome" tour
-            handle_welcome_screen unless (get_var("_welcome_done"));
+            handle_welcome_screen unless (get_var("_WELCOME_DONE"));
         }
     }
     if (get_version_major() > 8) {
-        handle_welcome_screen unless (get_var("_welcome_done"));
+        handle_welcome_screen unless (get_var("_WELCOME_DONE"));
     }
     if (get_var("DESKTOP") eq 'gnome' && get_var("INSTALL_NO_USER")) {
         # handle welcome screen if we didn't do it above (holy flow
         # control, Batman!)
-        handle_welcome_screen unless (get_var("_welcome_done"));
+        handle_welcome_screen unless (get_var("_WELCOME_DONE"));
         # if this was an image deployment, we also need to create
         # root user now, for subsequent tests to work
         if (get_var("IMAGE_DEPLOY")) {


### PR DESCRIPTION
# Description

This PR includes a fix for `_graphical_wait_login` which is broken with recent updates of os-autoinst. Tests with `_graphical_wait_login` are failing with...

```
# Test died: Settings key '_welcome_done' is invalid (check your test settings) at /usr/lib/os-autoinst/testapi.pm line 723.
```

<img width="1200" alt="01_install_default_upload_failure_in_graphical_wait_login" src="https://user-images.githubusercontent.com/542846/208743927-e31c11e6-582c-4ff0-956e-697f2601bb25.png">

This is a cherry pick of [**7675e99** Make internal state marker variables upper-case](https://pagure.io/fedora-qa/os-autoinst-distri-fedora/c/7675e99fccecbcad0360c0bf1e33e3662b24180d?branch=main) from Fedora openQA resolving this issue. Commit message for brief summary...

```
Make internal state marker variables upper-case.

We use variables to track test state across modules, sometimes.
As this is all internal to the test logic I didn't bother always
making these variables upper-case, but os-autoinst now treats
lower-case variables as a fatal error, so we have to change.

Signed-off-by: Adam Williamson <awilliam@redhat.com>
```

# How Has This Been Tested?

```
openqa-cli api -X POST isos ISO=Rocky-9.1-20221214.1-x86_64-dvd.iso ARCH=x86_64 DISTRI=rocky FLAVOR=dvd-iso VERSION=9.1 BUILD=-9.1-dvd-iso-$(date +%Y%m%d.%H%M%S).0
```

Tests with `_graphical_wait_login` (eg. `install_default_upload@64bit`) should pass.

<img width="1200" alt="02_install_default_upload_passed_in_graphical_wait_login" src="https://user-images.githubusercontent.com/542846/208743983-b6d3ed5b-54fb-435e-ae73-f86849b3bf6b.png">

In this particular example, passing `install_default_upload@64bit` opens up the dependency tree for `FLAVOR=dvd-iso` and exposes the rest of the test tree.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


