### PR TITLE
Fix custom_standard_partition_ext4_postinstall failures

### DIFF
--- a/tests/disk_custom_standard_partition_ext4_postinstall.pm
+++ b/tests/disk_custom_standard_partition_ext4_postinstall.pm
@@ -11,13 +11,13 @@ sub run {
     assert_screen "root_console";
     my $count = 4;
     my $devroot = 'vda1';
-    my $devboot = 'vda2';
-    my $devswap = 'vda3';
+    my $devswap = 'vda2';
+    my $devboot = 'vda3';
     if (get_var('OFW') || get_var('UEFI')) {
         $count = 5; # extra boot partition (PreP or ESP)
         $devroot = 'vda2';
-        $devboot = 'vda3';
-        $devswap = 'vda4';
+        $devswap = 'vda3';
+        $devboot = 'vda4';
     }
     # check number of partitions
     script_run 'fdisk -l | grep /dev/vda'; # debug


### PR DESCRIPTION
# Description

This PR fixes the `custom_standard_partition_ext4_postinstall` failures on checking for mounted disks. The volume indices have changed and were causing openQA to incorrectly report those volumes as missing.

# How Has This Been Tested?
```
# openqa-cli api -X POST isos ISO=Rocky-9.1-20221214.1-x86_64-dvd.iso ARCH=x86_64 DISTRI=rocky FLAVOR=universal VERSION=9.1 BUILD=-custom_standard_partition_ext4_postinstall_fails-universal-9.1
# openqa-cli api -X POST isos ISO=Rocky-9.1-20221214.1-x86_64-dvd.iso ARCH=x86_64 DISTRI=rocky FLAVOR=dvd-iso
VERSION=9.1 BUILD=-custom_standard_partition_ext4_postinstall_fails-dvd-iso-9.1
# openqa-cli api -X POST isos ISO=Rocky-8.7-x86_64-dvd1.iso ARCH=x86_64 DISTRI=rocky FLAVOR=universal VERSION=
8.7 BUILD=-custom_standard_partition_ext4_postinstall_fails-universal-8.7 
# openqa-cli api -X POST isos ISO=Rocky-8.7-x86_64-dvd1.iso ARCH=x86_64 DISTRI=rocky FLAVOR=dvd-iso VERSION=8.7 BUILD=-custom_standard_partition_ext4_postinstall_fails-dvd-iso-8.7 
```
Expected failures:
```
# FLAVOR=dvd-iso, VERSION=8.7 or VERSION=9.1
modularity_tests@modularity_module_list
# these two failures are addressed by PR#!42
server_cockpit_default@_setup_browser
server_filesystem_default@server_filesystem_default

# FLAVOR=universal, VERSION=8.7 or VERSION=9.1
install_anaconda_text@install_text
install_mirrorlist_graphical@_do_install_and_reboot
install_serial_console@_boot_to_anaconda
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
