### PR TITLE
add support for GenericCloud image testing

### DIFF
--- a/templates.fif.json
+++ b/templates.fif.json
@@ -54,7 +54,35 @@
         }
     },
     "Products": {
-        "rocky-boot-iso-aarch64-*": {
+        "rocky-GenericCloud_Base-qcow2-qcow2-x86_64-*": {
+            "arch": "x86_64",
+            "distri": "rocky",
+            "flavor": "GenericCloud_Base-qcow2-qcow2",
+            "settings": {
+                "BOOTFROM": "c",
+                "DEPLOY_UPLOAD_TEST": "",
+                "+HDD_1": "%HDD_2%",
+                "ISO": "cloudinit.iso",
+                "ROOT_PASSWORD": "weakpassword",
+                "TEST_TARGET": "HDD_1"
+            },
+            "version": "*"
+        },
+        "rocky-GenericCloud_LVM-qcow2-qcow2-x86_64-*": {
+            "arch": "x86_64",
+            "distri": "rocky",
+            "flavor": "GenericCloud_LVM-qcow2-qcow2",
+            "settings": {
+                "BOOTFROM": "c",
+                "DEPLOY_UPLOAD_TEST": "",
+                "+HDD_1": "%HDD_2%",
+                "ISO": "cloudinit.iso",
+                "ROOT_PASSWORD": "weakpassword",
+                "TEST_TARGET": "HDD_1"
+            },
+            "version": "*"
+        },
+	"rocky-boot-iso-aarch64-*": {
             "arch": "aarch64",
             "distri": "rocky",
             "flavor": "boot-iso",
@@ -166,7 +194,23 @@
         }
     },
     "Profiles": {
-        "rocky-boot-iso-aarch64-*-aarch64": {
+        "rocky-GenericCloud_Base-qcow2-qcow2-x86_64-*-64bit": {
+            "machine": "64bit",
+            "product": "rocky-GenericCloud_Base-qcow2-qcow2-x86_64-*"
+        },
+        "rocky-GenericCloud_LVM-qcow2-qcow2-x86_64-*-64bit": {
+            "machine": "64bit",
+            "product": "rocky-GenericCloud_LVM-qcow2-qcow2-x86_64-*"
+        },
+        "rocky-GenericCloud_Base-qcow2-qcow2-x86_64-*-uefi": {
+            "machine": "uefi",
+            "product": "rocky-GenericCloud_Base-qcow2-qcow2-x86_64-*"
+        },
+        "rocky-GenericCloud_LVM-qcow2-qcow2-x86_64-*-uefi": {
+            "machine": "uefi",
+            "product": "rocky-GenericCloud_LVM-qcow2-qcow2-x86_64-*"
+        },
+	"rocky-boot-iso-aarch64-*-aarch64": {
             "machine": "aarch64",
             "product": "rocky-boot-iso-aarch64-*"
         },
@@ -236,6 +280,10 @@
         },
         "base_reboot_unmount": {
             "profiles": {
+                "rocky-GenericCloud_Base-qcow2-qcow2-x86_64-*-64bit": 30,
+                "rocky-GenericCloud_Base-qcow2-qcow2-x86_64-*-uefi": 30,
+                "rocky-GenericCloud_LVM-qcow2-qcow2-x86_64-*-64bit": 30,
+                "rocky-GenericCloud_LVM-qcow2-qcow2-x86_64-*-uefi": 30,
                 "rocky-dvd-iso-aarch64-*-aarch64": 20,
                 "rocky-dvd-iso-x86_64-*-64bit": 20
             },
@@ -251,6 +299,10 @@
         },
         "base_system_logging": {
             "profiles": {
+                "rocky-GenericCloud_Base-qcow2-qcow2-x86_64-*-64bit": 30,
+                "rocky-GenericCloud_Base-qcow2-qcow2-x86_64-*-uefi": 30,
+                "rocky-GenericCloud_LVM-qcow2-qcow2-x86_64-*-64bit": 30,
+                "rocky-GenericCloud_LVM-qcow2-qcow2-x86_64-*-uefi": 30,
                 "rocky-dvd-iso-aarch64-*-aarch64": 20,
                 "rocky-dvd-iso-x86_64-*-64bit": 20
             },
@@ -266,6 +318,10 @@
         },
         "base_update_cli": {
             "profiles": {
+                "rocky-GenericCloud_Base-qcow2-qcow2-x86_64-*-64bit": 30,
+                "rocky-GenericCloud_Base-qcow2-qcow2-x86_64-*-uefi": 30,
+                "rocky-GenericCloud_LVM-qcow2-qcow2-x86_64-*-64bit": 30,
+                "rocky-GenericCloud_LVM-qcow2-qcow2-x86_64-*-uefi": 30,
                 "rocky-dvd-iso-aarch64-*-aarch64": 20,
                 "rocky-dvd-iso-x86_64-*-64bit": 20
             },
@@ -281,6 +337,10 @@
         },
         "base_package_install_remove": {
             "profiles": {
+                "rocky-GenericCloud_Base-qcow2-qcow2-x86_64-*-64bit": 30,
+                "rocky-GenericCloud_Base-qcow2-qcow2-x86_64-*-uefi": 30,
+                "rocky-GenericCloud_LVM-qcow2-qcow2-x86_64-*-64bit": 30,
+                "rocky-GenericCloud_LVM-qcow2-qcow2-x86_64-*-uefi": 30,
                 "rocky-dvd-iso-aarch64-*-aarch64": 40,
                 "rocky-dvd-iso-x86_64-*-64bit": 40
             },
@@ -296,6 +356,10 @@
         },
         "base_services_start": {
             "profiles": {
+                "rocky-GenericCloud_Base-qcow2-qcow2-x86_64-*-64bit": 30,
+                "rocky-GenericCloud_Base-qcow2-qcow2-x86_64-*-uefi": 30,
+                "rocky-GenericCloud_LVM-qcow2-qcow2-x86_64-*-64bit": 30,
+                "rocky-GenericCloud_LVM-qcow2-qcow2-x86_64-*-uefi": 30,
                 "rocky-dvd-iso-aarch64-*-aarch64": 40,
                 "rocky-dvd-iso-x86_64-*-64bit": 40
             },
@@ -311,6 +375,10 @@
         },
         "base_selinux": {
             "profiles": {
+                "rocky-GenericCloud_Base-qcow2-qcow2-x86_64-*-64bit": 30,
+                "rocky-GenericCloud_Base-qcow2-qcow2-x86_64-*-uefi": 30,
+                "rocky-GenericCloud_LVM-qcow2-qcow2-x86_64-*-64bit": 30,
+                "rocky-GenericCloud_LVM-qcow2-qcow2-x86_64-*-uefi": 30,
                 "rocky-dvd-iso-aarch64-*-aarch64": 40,
                 "rocky-dvd-iso-x86_64-*-64bit": 40
             },
@@ -326,6 +394,10 @@
         },
         "base_service_manipulation": {
             "profiles": {
+                "rocky-GenericCloud_Base-qcow2-qcow2-x86_64-*-64bit": 30,
+                "rocky-GenericCloud_Base-qcow2-qcow2-x86_64-*-uefi": 30,
+                "rocky-GenericCloud_LVM-qcow2-qcow2-x86_64-*-64bit": 30,
+                "rocky-GenericCloud_LVM-qcow2-qcow2-x86_64-*-uefi": 30,
                 "rocky-dvd-iso-aarch64-*-aarch64": 40,
                 "rocky-dvd-iso-x86_64-*-64bit": 40
             },
@@ -339,7 +411,18 @@
                 "USER_LOGIN": "false"
             }
         },
-        "install_resize_lvm": {
+        "cloud_autocloud": {
+            "profiles": {
+                "rocky-GenericCloud_Base-qcow2-qcow2-x86_64-*-64bit": 30,
+                "rocky-GenericCloud_Base-qcow2-qcow2-x86_64-*-uefi": 30,
+                "rocky-GenericCloud_LVM-qcow2-qcow2-x86_64-*-64bit": 30,
+                "rocky-GenericCloud_LVM-qcow2-qcow2-x86_64-*-uefi": 30
+            },
+            "settings": {
+                "POSTINSTALL": "autocloud"
+            }
+        },
+	"install_resize_lvm": {
             "profiles": {
                 "rocky-dvd-iso-aarch64-*-aarch64": 40,
                 "rocky-dvd-iso-x86_64-*-64bit": 40


### PR DESCRIPTION
# Description

This pull request will add support for GenericCloud image testing into the `templates.fif.json` file.

# How Has This Been Tested?

```bash
openqa-cli api -X POST isos ARCH=x86_64 DISTRI=rocky FLAVOR=GenericCloud_Base-qcow2-qcow2 VERSION=9.1 BUILD=9.1-GenericCloud_Base-$(date +%Y%m%d).0 HDD_2=Rocky-9-GenericCloud-Base.latest.x86_64.qcow2  HDD_2_URL=https://dl.rockylinux.org/pub/rocky/9.1/images/x86_64/Rocky-9-GenericCloud-Base.latest.x86_64.qcow2

openqa-cli api -X POST isos ARCH=x86_64 DISTRI=rocky FLAVOR=GenericCloud_LVM-qcow2-qcow2 VERSION=9.1 BUILD=9.1-GenericCloud_LVM-$(date +%Y%m%d).0 HDD_2=Rocky-9-GenericCloud-LVM.latest.x86_64.qcow2  HDD_2_URL=https://dl.rockylinux.org/pub/rocky/9.1/images/x86_64/Rocky-9-GenericCloud-LVM.latest.x86_64.qcow2

openqa-cli api -X POST isos ARCH=x86_64 DISTRI=rocky FLAVOR=GenericCloud_Base-qcow2-qcow2 VERSION=8.7 BUILD=8-GenericCloud_Base-$(date +%Y%m%d).0 HDD_2=Rocky-8-GenericCloud-Base.latest.x86_64.qcow2  HDD_2_URL=https://dl.rockylinux.org/pub/rocky/8/images/x86_64/Rocky-8-GenericCloud-Base.latest.x86_64.qcow2

openqa-cli api -X POST isos ARCH=x86_64 DISTRI=rocky FLAVOR=GenericCloud_LVM-qcow2-qcow2 VERSION=8.7 BUILD=8-GenericCloud_LVM-$(date +%Y%m%d).0 HDD_2=Rocky-8-GenericCloud-LVM.latest.x86_64.qcow2  HDD_2_URL=https://dl.rockylinux.org/pub/rocky/8/images/x86_64/Rocky-8-GenericCloud-LVM.latest.x86_64.qcow2
```

# Requirements

You must pull or create the `cloudinit.iso` to run the `GenericCloud` tests in openQA. Currently @tcooper has a [fork of Cloud-Init-ISO](https://github.com/tcooper/Cloud-Init-ISO/tree/develop) to produce the minimal content to satisfy this requirement. It's possible more advanced tests of `GenericCloud` images will need alternate `cloudinit.iso` content and those can/should be generated as required.

NOTE: Some tests do not currently pass in each OS  but adding support for running these tests will allow test/debug of the actual tests.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules