### PR TITLE
FIX: add selinux config for /var/tmp/rocky in _pxe_setup for support_server

### DIFF
--- a/tests/_support_server.pm
+++ b/tests/_support_server.pm
@@ -34,6 +34,10 @@ sub _pxe_setup {
         assert_script_run "mkdir -p /var/lib/tftpboot/pxelinux.cfg";
         # install bootloader packages
         assert_script_run "dnf -y install syslinux", 120;
+        # selinux compatible fcontext config required
+        assert_script_run "dnf -y install policycoreutils-python-utils", 120;
+        assert_script_run "semanage fcontext -a -e /var/lib/rpm /var/tmp/rocky", 60;
+        assert_script_run "restorecon -vvRF /var/tmp/rocky", 60;
         assert_script_run "rpm --root=/var/tmp/rocky --rebuilddb", 60;
         assert_script_run "cd /var/tmp; dnf download rocky-release rocky-repos rocky-gpg-keys", 60;
         assert_script_run "rpm --root=/var/tmp/rocky --nodeps -i /var/tmp/*.rpm", 60;


### PR DESCRIPTION
# Description

Current `support_server` test fails with...

```
# Test died: command 'rpm --root=/var/tmp/rocky --rebuilddb' failed at rocky/tests/_support_server.pm line 37.
```

![support_server_fail](https://user-images.githubusercontent.com/542846/218205776-388668d8-a508-4d47-8bf0-26d5af7bc24e.png) ([openQA test](https://openqa.rockylinux.org/tests/4195#step/_support_server/23))

This pull request will allow `_pxe_setup` of `support_server` test to complete successfully.

## openQA.rockylinux.org:
 - os-autoinst-distri-rocky: commit: [b0a55de](https://github.com/rocky-linux/os-autoinst-distri-rocky/commit/b0a55dee102594380b07052c759cc6d635942a74)

# How Has This Been Tested?

In a generic Rocky 9 Vagrant VM...

```bash
# replicate issue
[root@rocky9 ~]# cat /etc/rocky-release
Rocky Linux release 9.1 (Blue Onyx)

[root@rocky9 ~]# mkdir -p /var/tmp/rocky

[root@rocky9 ~]# rpm --root=/var/tmp/rocky --rebuilddb
error: cant create transaction lock on /var/tmp/rocky/var/lib/rpm/.rpm.lock (Permission denied)

# resolve issue with selinux content
[root@rocky9 ~]# dnf -y install policycoreutils-python-utils
...<snip>...

[root@rocky9 ~]# ls -ldZ /var/tmp/rocky
drwxr-xr-x. 2 root root unconfined_u:object_r:user_tmp_t:s0 6 Feb 10 21:38 /var/tmp/rocky

[root@rocky9 ~]# semanage fcontext -a -e /var/lib/rpm /var/tmp/rocky

[root@rocky9 ~]# restorecon -vvRF /var/tmp/rocky
Relabeled /var/tmp/rocky from unconfined_u:object_r:user_tmp_t:s0 to system_u:object_r:rpm_var_lib_t:s0

[root@rocky9 ~]# ls -ldZ /var/tmp/rocky
drwxr-xr-x. 5 root root system_u:object_r:rpm_var_lib_t:s0 39 Feb 10 21:42 /var/tmp/rocky

[root@rocky9 ~]# rpm --root=/var/tmp/rocky --rebuilddb

# continued support_server sequence
[root@rocky9 ~]# cd /var/tmp; dnf download rocky-release rocky-repos rocky-gpg-keys
Extra Packages for Enterprise Linux 9 - x86_64                                                     19 kB/s |  21 kB     00:01
(1/3): rocky-gpg-keys-9.1-1.11.el9.noarch.rpm                                                      23 kB/s |  12 kB     00:00
(2/3): rocky-repos-9.1-1.11.el9.noarch.rpm                                                         23 kB/s |  12 kB     00:00
(3/3): rocky-release-9.1-1.11.el9.noarch.rpm                                                       37 kB/s |  22 kB     00:00

[root@rocky9 tmp]# rpm --root=/var/tmp/rocky --nodeps -i /var/tmp/*.rpm
warning: /var/tmp/rocky-gpg-keys-9.1-1.11.el9.noarch.rpm: Header V4 RSA/SHA256 Signature, key ID 350d275d: NOKEY

[root@rocky9 tmp]# rpm --root=/var/tmp/rocky -qa
rocky-gpg-keys-9.1-1.11.el9.noarch
rocky-release-9.1-1.11.el9.noarch
rocky-repos-9.1-1.11.el9.noarch

...<cont>...
```

# How Should This Be Tested?

```bash
openqa-cli api -X POST isos ISO=Rocky-9.1-20221214.1-x86_64-dvd.iso ISO_URL=https://dl.rockylinux.org/pub/rocky/9/isos/x86_64/Rocky-9.1-20221214.1-x86_64-dvd.iso ARCH=x86_64 DISTRI=rocky FLAVOR=dvd-iso VERSION=9.1 CURRREL=9 BUILD=20230210-Rocky-9.1-x86_64.0 TEST=support_server
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules