### PR TITLE
Add perltidy support and apply it to the entire codebase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 .tox/
 .coverage
 coverage.xml
+.tidyall.d/

--- a/.perltidyrc
+++ b/.perltidyrc
@@ -1,0 +1,16 @@
+# Workaround needed for handling non-ASCII in files.
+# # See <https://github.com/houseabsolute/perl-code-tidyall/issues/84>.
+--character-encoding=none
+--no-valign
+# 120 characters would be desired but it is not feasible right now
+#-l=120   # 120 characters per line
+-l=160
+-fbl     # don't change blank lines
+-fnl	 # don't remove new lines
+-nsfs    # no spaces before semicolons
+-baao    # space after operators
+-bbao    # space before operators
+-pt=2    # no spaces around ()
+-bt=2    # no spaces around []
+-sbt=2   # no spaces around {}
+-sct     # stack closing tokens )}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,13 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v4.4.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
     -   id: check-json
     -   id: check-yaml
     -   id: check-added-large-files
+-   repo: https://github.com/henryykt/pre-commit-perl
+    rev: v0.0.5
+    hooks:
+    -   id: perltidy

--- a/.tidyallrc
+++ b/.tidyallrc
@@ -1,0 +1,3 @@
+[PerlTidy]
+select = **/*.pm
+argv = --profile=$ROOT/.perltidyrc

--- a/README_perltidy.md
+++ b/README_perltidy.md
@@ -1,0 +1,577 @@
+# Setup for running perltidy via pre-commit
+
+## Purpose
+
+Periodically it makes sense to be able to compare to our original upstream repository ([Fedora openQA](https://pagure.io/fedora-qa/os-autoinst-distri-fedora)) or even to cherry pick select improvements to our code. In the best case we might even contribute improvements or bug fixes back to Fedora. In order to do any of those things effectively it is good to keep the code we share with upstream as closely matching as possible.
+
+After we forked from upstream the Fedora QA team [began using `perltidy`](https://pagure.io/fedora-qa/os-autoinst-distri-fedora/pull-request/271) to apply and enforce consistent coding stardards to their openQA test code. Additionally, they modified all existing code to implement these coding standards uniformly across the entire repository.
+
+If we adopt the same standard we will benefit from being able to...
+
+- directly compare code in our fork originating from upstream,
+- more easily import any existing upstream code
+- and we'll also improve our own code quality.
+
+
+## Pre-Requisites
+
+- pre-commit - [https://pre-commit.com/](https://pre-commit.com/)
+- perltidy - [https://metacpan.org/dist/Perl-Tidy/view/bin/perltidy](https://metacpan.org/dist/Perl-Tidy/view/bin/perltidy)
+- tidyall - [https://metacpan.org/dist/Code-TidyAll/view/bin/tidyall](https://metacpan.org/dist/Code-TidyAll/view/bin/tidyall)
+
+
+Install above in your dev system via you preferred method. I used [`cpanm`](https://metacpan.org/dist/App-cpanminus/view/bin/cpanm) to install `Perl::Tidy` and `Code::TidyAll` in my macOS system and `cpanm` was installed with Homebrew.
+
+
+### install `cpanm`
+```
+$ brew install cpanminus
+==> Fetching cpanminus
+==> Downloading https://ghcr.io/v2/homebrew/core/cpanminus/manifests/1.7046
+Already downloaded: /Users/tcooper/Library/Caches/Homebrew/downloads/269f7cc3d0d07bf233458f3bf1d604ae2e8669d59eeb91e273bfda684987519f--cpanminus-1.7046.bottle_manifest.json
+==> Downloading https://ghcr.io/v2/homebrew/core/cpanminus/blobs/sha256:ab901b1645c97fa50ee52ecc4bf51bac7f8a8959abe664bbdd66c3d1a5
+Already downloaded: /Users/tcooper/Library/Caches/Homebrew/downloads/d3cf41a8aca082cd90acdfa8d79fc89e2b17d3ab13a2953b2bb58083a38a0779--cpanminus--1.7046.ventura.bottle.tar.gz
+==> Pouring cpanminus--1.7046.ventura.bottle.tar.gz
+==> Adding `/usr/bin/env perl` shebang to `cpanm`...
+🍺  /usr/local/Cellar/cpanminus/1.7046: 11 files, 1.2MB
+==> Running `brew cleanup cpanminus`...
+Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
+Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
+
+$ which cpanm
+/usr/local/bin/cpanm
+```
+
+**NOTE: Homebrew automatically configures your default shell for `cpanm`.**
+
+
+### install `perltidy`
+```
+$ cpanm --info Perl::Tidy
+SHANCOCK/Perl-Tidy-20221112.tar.gz
+$ cpanm Perl::Tidy
+--> Working on Perl::Tidy
+Fetching http://www.cpan.org/authors/id/S/SH/SHANCOCK/Perl-Tidy-20221112.tar.gz ... OK
+Configuring Perl-Tidy-20221112 ... OK
+Building and testing Perl-Tidy-20221112 ... OK
+Successfully installed Perl-Tidy-20221112
+1 distribution installed
+
+$ which perltidy
+/Users/tcooper/perl5/bin/perltidy
+```
+
+### install `tidyall`
+```
+$ cpanm --info Code::TidyAll
+DROLSKY/Code-TidyAll-0.83.tar.gz
+
+$ cpanm Code::TidyAll
+--> Working on Code::TidyAll
+Fetching http://www.cpan.org/authors/id/D/DR/DROLSKY/Code-TidyAll-0.83.tar.gz ... OK
+Configuring Code-TidyAll-0.83 ... OK
+Building and testing Code-TidyAll-0.83 ... OK
+Successfully installed Code-TidyAll-0.83
+1 distribution installed
+
+$ which tidyall
+/Users/tcooper/perl5/bin/tidyall
+```
+
+In an RPM based system like Rocky Linux or Fedora `Perl::Tidy` and `Code::TidyAll` may be installable, along with all dependencies, directly from the provided repositories.
+
+### install `cpanm` in Rocky Linux 8
+
+```
+# dnf config-manager --set-enabled powertools
+# dnf install perl-App-cpanminus
+Rocky Linux 8 - AppStream                                                                         7.4 kB/s | 4.8 kB     00:00
+Rocky Linux 8 - BaseOS                                                                            4.3 kB/s | 4.3 kB     00:01
+Rocky Linux 8 - Extras                                                                            8.2 kB/s | 3.1 kB     00:00
+Rocky Linux 8 - PowerTools                                                                        8.4 kB/s | 4.8 kB     00:00
+Extra Packages for Enterprise Linux 8 - x86_64                                                     17 kB/s | 8.7 kB     00:00
+Extra Packages for Enterprise Linux 8 - x86_64                                                    841 kB/s |  13 MB     00:16
+Dependencies resolved.
+==================================================================================================================================
+ Package                                Architecture     Version                                        Repository           Size
+==================================================================================================================================
+Installing:
+ perl-App-cpanminus                     noarch           1.7044-5.module+el8.6.0+961+8164b543           appstream            97 k
+ perltidy                               noarch           20180220-1.el8                                 powertools          427 k
+Installing dependencies:
+ annobin                                x86_64           10.67-3.el8                                    appstream           954 k
+
+...<snip>...
+
+  unzip-6.0-46.el8.x86_64
+  zip-3.0-23.el8.x86_64
+
+Complete!
+
+# which cpanm
+/usr/bin/cpanm
+
+# which perltidy
+/usr/bin/perltidy
+```
+
+### configure `.bash_profile` for `cpanm`
+
+Append your `$HOME/.bash_profile` file with the following if not already setup...
+
+```
+PATH="$HOME/perl5/bin${PATH:+:${PATH}}"; export PATH;
+PERL5LIB="$HOME/perl5/lib/perl5${PERL5LIB:+:${PERL5LIB}}"; export PERL5LIB;
+PERL_LOCAL_LIB_ROOT="$HOME/perl5${PERL_LOCAL_LIB_ROOT:+:${PERL_LOCAL_LIB_ROOT}}"; export PERL_LOCAL_LIB_ROOT;
+PERL_MB_OPT="--install_base \"$HOME/perl5\""; export PERL_MB_OPT;
+PERL_MM_OPT="INSTALL_BASE=$HOME/perl5"; export PERL_MM_OPT;
+```
+
+
+With `cpanm` installed you can follow steps above to install `Code::TidyAll`.
+
+#### install `tidyall`
+
+```
+$ cpanm -l ~/perl5 --info Code::TidyAll
+DROLSKY/Code-TidyAll-0.83.tar.gz
+
+$ cpanm -l ~/perl5 Code::TidyAll
+--> Working on Code::TidyAll
+Fetching http://www.cpan.org/authors/id/D/DR/DROLSKY/Code-TidyAll-0.83.tar.gz ... OK
+Configuring Code-TidyAll-0.83 ... OK
+==> Found dependencies: List::SomeUtils, Specio, Specio::Library::String, Test::Class::Most, Time::Duration::Parse, Specio::Library::Path::Tiny, List::Compare, Try::Tiny, Test::Fatal, Date::Format, Specio::Library::Builtins, Capture::Tiny, Module::Runtime, Specio::Library::Numeric, IPC::Run3, Log::Any, Scope::Guard, Moo, Path::Tiny, Specio::Declare, Test::Warnings, Moo::Role, Test::Differences, lib::relative, Config::INI::Reader
+
+...<snip>...
+
+Building and testing Code-TidyAll-0.83 ... OK
+Successfully installed Code-TidyAll-0.83
+43 distributions installed
+
+$ which tidyall
+~/perl5/bin/tidyall
+```
+
+
+### install `cpanm` and `perltidy` in Rocky Linux 9
+
+```
+$ sudo dnf install perltidy perl-App-cpanminus
+Last metadata expiration check: 0:06:42 ago on Sun Feb 12 19:29:29 2023.
+Dependencies resolved.
+==================================================================================================================================
+ Package                                    Architecture         Version                            Repository               Size
+==================================================================================================================================
+Installing:
+ perl-App-cpanminus                         noarch               1.7044-14.el9                      appstream                86 k
+ perltidy                                   noarch               20210111-4.el9                     crb                     541 k
+
+ ...<snip>...
+
+  perl-utils-5.32.1-479.el9.noarch                               perl-vmsish-1.04-479.el9.noarch
+  perltidy-20210111-4.el9.noarch                                 sombok-2.4.0-16.el9.x86_64
+  systemtap-sdt-devel-4.7-2.el9.x86_64
+
+Complete!
+
+$ which cpanm
+/usr/bin/cpanm
+
+$ which perltidy
+/usr/bin/perltidy
+```
+
+With `cpanm` and `perltidy` installed you can follow steps above to install `Code::TidyAll`.
+
+
+### install `perltidy` and `tidyall` in Fedora 37 (`cpanm` not required)
+
+```
+# dnf install perltidy perl-Code-TidyAll
+Last metadata expiration check: 0:03:32 ago on Mon 13 Feb 2023 03:59:12 AM UTC.
+Dependencies resolved.
+==================================================================================================================================
+ Package                                    Architecture        Version                                Repository            Size
+==================================================================================================================================
+Installing:
+ perl-Code-TidyAll                          noarch              0.82-3.fc37                            fedora               169 k
+ perltidy                                   noarch              20220613-2.fc37                        fedora               655 k
+
+...<snip>...
+
+  php-soap-8.1.15-1.fc37.x86_64                                      php-xml-8.1.15-1.fc37.x86_64
+  subversion-1.14.2-8.fc37.x86_64                                    subversion-libs-1.14.2-8.fc37.x86_64
+  utf8proc-2.7.0-3.fc37.x86_64
+
+Complete!
+
+# which perltidy
+/usr/bin/perltidy
+
+# which tidyall
+/usr/bin/tidyall
+```
+
+
+## `perltidy` usage
+
+With the `.perltidyrc` configuration adopted from upstream analysis (and repair) of Perl source files is possible. For example...
+
+```
+$ perltidy -st main.pm > main.pm.tidy
+```
+
+```
+$ diff main.pm main.pm.tidy
+36c36
+<     my @a   = @{ needle::tags($tag) };
+---
+>     my @a = @{needle::tags($tag)};
+52c52
+<     NEEDLE: for my $needle ( needle::all() ) {
+---
+>   NEEDLE: for my $needle (needle::all()) {
+54c54
+<         for my $tag ( @{$needle->{'tags'}} ) {
+---
+>         for my $tag (@{$needle->{'tags'}}) {
+59c59
+<                 for my $value ( @{$valueref} ) {
+---
+>                 for my $value (@{$valueref}) {
+88c88
+<         unregister_prefix_tags('DESKTOP', [ get_var('DESKTOP') ])
+---
+>         unregister_prefix_tags('DESKTOP', [get_var('DESKTOP')]);
+94c94
+<     my $langref = [ get_var('LANGUAGE') || 'english' ];
+---
+>     my $langref = [get_var('LANGUAGE') || 'english'];
+198c198
+<     if (! $partitioning || $partitioning ~~ ['guided_empty', 'guided_free_space']) {
+---
+>     if (!$partitioning || $partitioning ~~ ['guided_empty', 'guided_free_space']) {
+202c202
+<         $storage = "tests/disk_".$partitioning.".pm";
+---
+>         $storage = "tests/disk_" . $partitioning . ".pm";
+206c206
+<     if (get_var("ENCRYPT_PASSWORD")){
+---
+>     if (get_var("ENCRYPT_PASSWORD")) {
+333c333
+<     if (get_var("UEFI") &! get_var("NO_UEFI_POST") &! get_var("START_AFTER_TEST")) {
+---
+>     if (get_var("UEFI") & !get_var("NO_UEFI_POST") & !get_var("START_AFTER_TEST")) {
+```
+
+It should be evident from the above that without these changes it will become challenging to detect differences between our code and upstream code moving forward from the point where Fedora QA applied these code standards to all sources.
+
+
+## Using `tidy` to check and/or fix code
+
+The utility wrapper `tidy` provided by Fedora in the upstream repository can be used to launch `tidyall` with options described in `tidy`.
+
+For example, dropping an untidy'd copy of our `main.pm` as `foo.pm`...
+
+```
+[geekotest@openqa-dev ~]$ cd /var/lib/openqa/tests/rocky
+
+[geekotest@openqa-dev rocky]$ ./tidy --check foo.pm
+[checked] foo.pm
+*** needs tidying
+
+[geekotest@openqa-dev rocky]$ ./tidy foo.pm
+[tidied]  foo.pm
+
+[geekotest@openqa-dev rocky]$ ls .tidyall.d/backups/
+foo.pm-20230212-203202.bak
+```
+
+```
+[geekotest@openqa-dev rocky]$ diff .tidyall.d/backups/foo.pm-20230212-203202.bak foo.pm
+36c36
+<     my @a   = @{ needle::tags($tag) };
+---
+>     my @a = @{needle::tags($tag)};
+52c52
+<     NEEDLE: for my $needle ( needle::all() ) {
+---
+>   NEEDLE: for my $needle (needle::all()) {
+54c54
+<         for my $tag ( @{$needle->{'tags'}} ) {
+---
+>         for my $tag (@{$needle->{'tags'}}) {
+59c59
+<                 for my $value ( @{$valueref} ) {
+---
+>                 for my $value (@{$valueref}) {
+88c88
+<         unregister_prefix_tags('DESKTOP', [ get_var('DESKTOP') ])
+---
+>         unregister_prefix_tags('DESKTOP', [get_var('DESKTOP')]);
+94c94
+<     my $langref = [ get_var('LANGUAGE') || 'english' ];
+---
+>     my $langref = [get_var('LANGUAGE') || 'english'];
+198c198
+<     if (! $partitioning || $partitioning ~~ ['guided_empty', 'guided_free_space']) {
+---
+>     if (!$partitioning || $partitioning ~~ ['guided_empty', 'guided_free_space']) {
+202c202
+<         $storage = "tests/disk_".$partitioning.".pm";
+---
+>         $storage = "tests/disk_" . $partitioning . ".pm";
+206c206
+<     if (get_var("ENCRYPT_PASSWORD")){
+---
+>     if (get_var("ENCRYPT_PASSWORD")) {
+333c333
+<     if (get_var("UEFI") &! get_var("NO_UEFI_POST") &! get_var("START_AFTER_TEST")) {
+---
+>     if (get_var("UEFI") & !get_var("NO_UEFI_POST") & !get_var("START_AFTER_TEST")) {
+```
+
+
+## Automatic application with pre-commit
+
+While it's possible to manually apply these corrections using `tidy` when adding tests it is easy to forget this step and may be preferable to to use `pre-commit` to automatically check/apply these changes during normal workflow of developing and adding tests to openQA.
+
+With `pre-commit` setup in your local clone you are able to do this easily for any new tests added to the repository.
+
+For example...
+
+```
+$ cp main.pm foo.pm
+$ git add foo.pm
+$ pre-commit run
+trim trailing whitespace.................................................Passed
+fix end of files.........................................................Passed
+check json...........................................(no files to check)Skipped
+check yaml...........................................(no files to check)Skipped
+check for added large files..............................................Passed
+perltidy.................................................................Failed
+- hook id: perltidy
+- files were modified by this hook
+```
+
+...the issues are detected and automatically corrected...
+
+```
+$ git --no-pager diff foo.pm
+diff --git a/foo.pm b/foo.pm
+index b8470550..7a873fe2 100644
+--- a/foo.pm
++++ b/foo.pm
+@@ -33,7 +33,7 @@ testapi::set_distribution(fedoradistribution->new());
+ # Stolen from openSUSE.
+ sub unregister_needle_tags($) {
+     my $tag = shift;
+-    my @a   = @{ needle::tags($tag) };
++    my @a = @{needle::tags($tag)};
+     for my $n (@a) { $n->unregister(); }
+ }
+
+@@ -49,14 +49,14 @@ sub unregister_needle_tags($) {
+ # 'LANGUAGE-' at all.
+ sub unregister_prefix_tags {
+     my ($prefix, $valueref) = @_;
+-    NEEDLE: for my $needle ( needle::all() ) {
++  NEEDLE: for my $needle (needle::all()) {
+         my $unregister = 0;
+-        for my $tag ( @{$needle->{'tags'}} ) {
++        for my $tag (@{$needle->{'tags'}}) {
+             if ($tag =~ /^\Q$prefix/) {
+                 # We have at least one tag matching the prefix, so we
+                 # *MAY* want to un-register the needle
+                 $unregister = 1;
+-                for my $value ( @{$valueref} ) {
++                for my $value (@{$valueref}) {
+                     # At any point if we hit a prefix-value match, we
+                     # know we need to keep this needle and can skip
+                     # to the next
+@@ -85,13 +85,13 @@ sub cleanup_needles() {
+
+     # Unregister desktop needles of other desktops when DESKTOP is specified
+     if (get_var('DESKTOP')) {
+-        unregister_prefix_tags('DESKTOP', [ get_var('DESKTOP') ])
++        unregister_prefix_tags('DESKTOP', [get_var('DESKTOP')]);
+     }
+
+     # Unregister non-language-appropriate needles. See unregister_except_
+     # tags for details; basically all needles with at least one LANGUAGE-
+     # tag will be unregistered unless they match the current langauge.
+-    my $langref = [ get_var('LANGUAGE') || 'english' ];
++    my $langref = [get_var('LANGUAGE') || 'english'];
+     unregister_prefix_tags('LANGUAGE', $langref);
+ }
+ $needle::cleanuphandler = \&cleanup_needles;
+@@ -195,15 +195,15 @@ sub load_install_tests() {
+     my $partitioning = get_var('PARTITIONING');
+     # if PARTITIONING is unset, or one of [...], use disk_guided_empty,
+     # which is the simplest / 'default' case.
+-    if (! $partitioning || $partitioning ~~ ['guided_empty', 'guided_free_space']) {
++    if (!$partitioning || $partitioning ~~ ['guided_empty', 'guided_free_space']) {
+         $storage = "tests/disk_guided_empty.pm";
+     }
+     else {
+-        $storage = "tests/disk_".$partitioning.".pm";
++        $storage = "tests/disk_" . $partitioning . ".pm";
+     }
+     autotest::loadtest $storage;
+
+-    if (get_var("ENCRYPT_PASSWORD")){
++    if (get_var("ENCRYPT_PASSWORD")) {
+         autotest::loadtest "tests/disk_guided_encrypted.pm";
+     }
+
+@@ -330,7 +330,7 @@ sub load_postinstall_tests() {
+     }
+     autotest::loadtest $storagepost if ($storagepost);
+
+-    if (get_var("UEFI") &! get_var("NO_UEFI_POST") &! get_var("START_AFTER_TEST")) {
++    if (get_var("UEFI") & !get_var("NO_UEFI_POST") & !get_var("START_AFTER_TEST")) {
+         autotest::loadtest "tests/uefi_postinstall.pm";
+     }
+```
+
+
+## Automatic application of check/modify with git pre-commit hook
+
+By adding the perltidy hook to the `pre-commit` configuration the hook is automatically run when trying to commit Perl code. If problems are found they are fixed and the the commit is rejected allowing you an opportunity to investigate before continuing.
+
+### add file and attempt commit (rejected with file modified with perltidy)
+
+```
+$ cp main.pm foo.pm
+$ git add foo.pm
+$ git commit -m "add foo.pm"
+trim trailing whitespace.................................................Passed
+fix end of files.........................................................Passed
+check json...........................................(no files to check)Skipped
+check yaml...........................................(no files to check)Skipped
+check for added large files..............................................Passed
+perltidy.................................................................Failed
+- hook id: perltidy
+- files were modified by this hook
+
+$ git add foo.pm
+```
+
+### commit now
+
+```
+$ git add foo.pm
+$ git commit -m "add foo.pm"
+trim trailing whitespace.................................................Passed
+fix end of files.........................................................Passed
+check json...........................................(no files to check)Skipped
+check yaml...........................................(no files to check)Skipped
+check for added large files..............................................Passed
+perltidy.................................................................Passed
+[add_perltidy_support 19720035] add foo.pm
+ 1 file changed, 454 insertions(+)
+ create mode 100644 foo.pm
+```
+
+## Automatically tidying all existing code
+
+`perltidy` and `tidy` can check specific files and the `pre-commit` hook can check any new files added to the repository in new commits.
+
+How do we repair all of the existing code in the repository so that it matches upstream?
+
+For that we can use `tidyall` for everything in the hierarchy of our openQA repository. For example...
+
+```
+$ tidyall --check-only -a
+[checked] main.pm
+*** needs tidying
+[checked] tests/server_cockpit_default.pm
+*** needs tidying
+[checked] tests/disk_guided_delete_partial_postinstall.pm
+*** needs tidying
+
+...<snip>...
+
+[checked] lib/utils.pm
+*** needs tidying
+[checked] lib/anacondatest.pm
+*** needs tidying
+```
+
+```
+$ tidyall -a
+[tidied]  main.pm
+[tidied]  tests/server_cockpit_default.pm
+[tidied]  tests/disk_guided_delete_partial_postinstall.pm
+
+...<snip>...
+
+[tidied]  lib/modularity.pm
+[tidied]  lib/utils.pm
+[tidied]  lib/anacondatest.pm
+```
+
+```
+$ git status
+On branch add_perltidy_support
+Changes not staged for commit:
+  (use "git add <file>..." to update what will be committed)
+  (use "git restore <file>..." to discard changes in working directory)
+	modified:   lib/anaconda.pm
+	modified:   lib/anacondatest.pm
+	modified:   lib/bugzilla.pm
+
+...<snip>...
+
+	modified:   tests/upgrade_preinstall.pm
+	modified:   tests/upgrade_run.pm
+	modified:   tests/workstation_core_applications.pm
+
+Untracked files:
+  (use "git add <file>..." to include in what will be committed)
+	.tidyall.d/
+	.tidyallrc
+	README_perltidy.md
+
+no changes added to commit (use "git add" and/or "git commit -a")
+```
+
+```
+$ git add $(git status -s | awk '/\.pm$/ {print $2}')
+
+$ git commit -m "enforce standard coding on all Perl files"
+trim trailing whitespace.................................................Passed
+fix end of files.........................................................Passed
+check json...........................................(no files to check)Skipped
+check yaml...........................................(no files to check)Skipped
+check for added large files..............................................Passed
+perltidy.................................................................Passed
+[add_perltidy_support 61d57d45] enforce standard coding on all Perl files
+ 237 files changed, 950 insertions(+), 950 deletions(-)
+```
+
+```
+$ git --no-pager log -n2
+commit 61d57d4591bc37798b87b54eae44a016538f8880 (HEAD -> add_perltidy_support)
+gpg: Signature made Sun Feb 12 14:59:40 2023 PST
+gpg:                using RSA key 2CA999800D11C5946C9DBFEE52364D7BBCEB35B8
+gpg: Good signature from "Trevor Cooper <tcooper@sdsc.edu>" [ultimate]
+gpg:                 aka "Trevor Cooper <tcooper@ucsd.edu>" [ultimate]
+gpg:                 aka "Trevor Cooper <tcooper@rockylinux.org>" [ultimate]
+Author: Trevor Cooper <tcooper@rockylinux.org>
+Date:   Sun Feb 12 14:59:37 2023 -0800
+
+    enforce standard coding on all Perl files
+
+commit 4bfc29fc691568f36391560818fca0e7a3f7cac7
+gpg: Signature made Sun Feb 12 14:08:53 2023 PST
+gpg:                using RSA key 2CA999800D11C5946C9DBFEE52364D7BBCEB35B8
+gpg: Good signature from "Trevor Cooper <tcooper@sdsc.edu>" [ultimate]
+gpg:                 aka "Trevor Cooper <tcooper@ucsd.edu>" [ultimate]
+gpg:                 aka "Trevor Cooper <tcooper@rockylinux.org>" [ultimate]
+Author: Trevor Cooper <tcooper@rockylinux.org>
+Date:   Sun Feb 12 14:08:52 2023 -0800
+
+    add support for perltidy and pre-commit
+```

--- a/README_perltidy.md
+++ b/README_perltidy.md
@@ -1,4 +1,4 @@
-# Setup for running perltidy via pre-commit
+# Using perltidy, tidyall and tidy with the repository
 
 ## Purpose
 

--- a/lib/anaconda.pm
+++ b/lib/anaconda.pm
@@ -28,8 +28,8 @@ sub select_disks {
     );
     my %iscsi = %{$args{iscsi}};
     # Anaconda hub
-    assert_screen "anaconda_main_hub", 300; #
-    # Damn animation delay can cause bad clicks here too - wait for it
+    assert_screen "anaconda_main_hub", 300;    #
+                                               # Damn animation delay can cause bad clicks here too - wait for it
     sleep 1;
     assert_and_click "anaconda_main_hub_install_destination";
 
@@ -150,7 +150,7 @@ sub custom_blivet_add_partition {
         assert_and_click "anaconda_blivet_size_unit";
         assert_and_click "anaconda_blivet_size_unit_mib";
 
-        send_key "shift-tab";  # input is one tab back from unit selection listbox
+        send_key "shift-tab";    # input is one tab back from unit selection listbox
 
         # size input can contain whole set of different values, so we can't match it with needle
         type_safely $args{size} . "\n";
@@ -178,7 +178,7 @@ sub custom_blivet_add_partition {
 sub custom_add_partition {
     # Used to add partition on Rocky custom-gui partitioning screen
     # in Anaconda. Should be called when custom-gui is displayed and free space is selected.
-    # You can pass device type for partition (needle tagged anaconda_custom_devicetype_$devicetype should exist), size of that partition in MiBs, desired filesystem of that partition
+# You can pass device type for partition (needle tagged anaconda_custom_devicetype_$devicetype should exist), size of that partition in MiBs, desired filesystem of that partition
     # (anaconda_custom_part_fs_$filesystem should exist) and mountpoint of that partition (e. g. string "/boot").
     my %args = (
         devicetype => "",
@@ -368,7 +368,7 @@ sub get_full_repo {
     if ($repourl !~ m/^(nfs|hd:)/) {
         # Everything variant doesn't exist for modular composes atm,
         # only Server
-        $repourl .= "/".get_var("ARCH")."/os";
+        $repourl .= "/" . get_var("ARCH") . "/os";
     }
     return $repourl;
 }
@@ -483,7 +483,7 @@ sub report_bug_text {
     my $timestamp = time();
     #
     # First, collect the credentials.
-    my $login  = get_var("BUGZILLA_LOGIN");
+    my $login = get_var("BUGZILLA_LOGIN");
     my $password = get_var("_SECRET_BUGZILLA_PASSWORD");
     my $apikey = get_var("_SECRET_BUGZILLA_APIKEY");
     # Choose item 1 - Report the bug.

--- a/lib/anacondatest.pm
+++ b/lib/anacondatest.pm
@@ -21,7 +21,7 @@ sub post_fail_hook {
     if (check_screen "anaconda_error_report", 10) {
         assert_and_click "anaconda_error_report";
         $has_traceback = 1;
-    } elsif (check_screen "anaconda_text_error", 10) {  # also for text install
+    } elsif (check_screen "anaconda_text_error", 10) {    # also for text install
         type_string "1\n";
         $has_traceback = 1;
     }
@@ -73,21 +73,21 @@ sub post_fail_hook {
     }
 
     if ($dracut) {
-        upload_logs "/run/initramfs/rdsosreport.txt", failok=>1;
+        upload_logs "/run/initramfs/rdsosreport.txt", failok => 1;
         # that's all that's really useful, so...
         return;
     }
 
-    upload_logs "/tmp/X.log", failok=>1;
-    upload_logs "/tmp/anaconda.log", failok=>1;
-    upload_logs "/tmp/packaging.log", failok=>1;
-    upload_logs "/tmp/storage.log", failok=>1;
-    upload_logs "/tmp/syslog", failok=>1;
-    upload_logs "/tmp/program.log", failok=>1;
-    upload_logs "/tmp/dnf.log", failok=>1;
-    upload_logs "/tmp/dnf.librepo.log", failok=>1;
-    upload_logs "/tmp/dnf.rpm.log", failok=>1;
-    upload_logs "/tmp/dbus.log", failok=>1;
+    upload_logs "/tmp/X.log", failok => 1;
+    upload_logs "/tmp/anaconda.log", failok => 1;
+    upload_logs "/tmp/packaging.log", failok => 1;
+    upload_logs "/tmp/storage.log", failok => 1;
+    upload_logs "/tmp/syslog", failok => 1;
+    upload_logs "/tmp/program.log", failok => 1;
+    upload_logs "/tmp/dnf.log", failok => 1;
+    upload_logs "/tmp/dnf.librepo.log", failok => 1;
+    upload_logs "/tmp/dnf.rpm.log", failok => 1;
+    upload_logs "/tmp/dbus.log", failok => 1;
 
     if ($has_traceback) {
         # Upload Anaconda traceback logs
@@ -131,7 +131,7 @@ sub root_console {
         # tty3 has a shell on all f31+ installer and live images
         send_key "ctrl-alt-f3";
     }
-    console_login(user=>"root", timeout=>$args{timeout});
+    console_login(user => "root", timeout => $args{timeout});
 }
 
 1;

--- a/lib/bugzilla.pm
+++ b/lib/bugzilla.pm
@@ -32,7 +32,7 @@ sub convert_to_bz_timestamp {
 
 sub get_newest_bug {
     # This subroutine makes an API call to Bugzilla and
-    # fetches the newest bug that have been created. 
+    # fetches the newest bug that have been created.
     # This will be the bug created by Anaconda in this
     # test run.
     my ($timestamp, $login) = @_;

--- a/lib/cockpit.pm
+++ b/lib/cockpit.pm
@@ -24,7 +24,7 @@ sub start_cockpit {
     assert_screen "cockpit_login", 60;
     # this happened on early Modular Server composes...
     record_soft_failure "Unbranded Cockpit" if (match_has_tag "cockpit_login_unbranded");
-    wait_still_screen(stilltime=>5, similarity_level=>45);
+    wait_still_screen(stilltime => 5, similarity_level => 45);
     if ($login) {
         type_safely "root";
         wait_screen_change { send_key "tab"; };
@@ -57,6 +57,6 @@ sub check_updates {
     my $logfile = shift;
     sleep 2;
     my $checkresult = script_run "dnf check-update > $logfile";
-    upload_logs "$logfile", failok=>1;
-    return($checkresult);
+    upload_logs "$logfile", failok => 1;
+    return ($checkresult);
 }

--- a/lib/fedoradistribution.pm
+++ b/lib/fedoradistribution.pm
@@ -41,7 +41,7 @@ sub x11_start_program {
     send_key "alt-f2";
     assert_screen "desktop_runner";
     type_string $program, 20;
-    sleep 5; # because of KDE dialog - SUSE guys are doing the same!
+    sleep 5;    # because of KDE dialog - SUSE guys are doing the same!
     send_key "ret", 1;
 }
 

--- a/lib/freeipa.pm
+++ b/lib/freeipa.pm
@@ -44,7 +44,7 @@ sub start_webui {
     disable_firefox_studies;
     type_string "startx /usr/bin/firefox -width 1024 -height 768 https://ipa001.test.openqa.fedoraproject.org\n";
     assert_screen ["freeipa_webui_login", $user_screen], 60;
-    wait_still_screen(stilltime=>5, similarity_level=>45);
+    wait_still_screen(stilltime => 5, similarity_level => 45);
     # softfail on kerberos ticket bugs meaning we get auto-logged in
     # as the requested user when we don't expect to be
     if (match_has_tag $user_screen) {

--- a/lib/installedtest.pm
+++ b/lib/installedtest.pm
@@ -16,7 +16,7 @@ sub root_console {
     # Switch to a default or specified TTY and log in as root.
     my $self = shift;
     my %args = (
-        tty => 1, # what TTY to login to
+        tty => 1,    # what TTY to login to
         @_);
     if (get_var("SERIAL_CONSOLE")) {
         # select the first virtio terminal, for now we assume we can
@@ -27,7 +27,7 @@ sub root_console {
         # For normal terminal emulation, use key combo to reach a tty
         send_key "ctrl-alt-f$args{tty}";
     }
-    console_login; # Do the login.
+    console_login;    # Do the login.
 }
 
 sub post_fail_hook {
@@ -43,7 +43,7 @@ sub post_fail_hook {
         assert_script_run "dhclient";
     }
     else {
-        $self->root_console(tty=>6);
+        $self->root_console(tty => 6);
         # fix up keyboard layout, if we failed before the test did this
         # itself; if it's already been done, should be safe, will just
         # fail and carry on
@@ -88,7 +88,7 @@ sub post_fail_hook {
     }
 
     if ($dracut) {
-        upload_logs "/run/initramfs/rdsosreport.txt", failok=>1;
+        upload_logs "/run/initramfs/rdsosreport.txt", failok => 1;
         # that's all that's really useful, so...
         return;
     }
@@ -125,14 +125,14 @@ sub post_fail_hook {
     }
 
     # Sometimes useful for diagnosing FreeIPA issues
-    upload_logs "/etc/nsswitch.conf", failok=>1;
+    upload_logs "/etc/nsswitch.conf", failok => 1;
 
     if (get_var("FLAVOR") eq "updates-everything-boot-iso") {
         # for installer creation test
         script_run "df -h";
-        upload_logs "/root/imgbuild/pylorax.log", failok=>1;
-        upload_logs "/root/imgbuild/lorax.log", failok=>1;
-        upload_logs "/root/imgbuild/program.log", failok=>1;
+        upload_logs "/root/imgbuild/pylorax.log", failok => 1;
+        upload_logs "/root/imgbuild/lorax.log", failok => 1;
+        upload_logs "/root/imgbuild/program.log", failok => 1;
     }
 
     if (get_var("TEST") eq "live_build") {
@@ -149,10 +149,10 @@ sub post_fail_hook {
     }
 }
 
-    # For update tests, let's do the update package info log stuff,
-    # it may be useful for diagnosing the cause of the failure
-    advisory_get_installed_packages;
-    advisory_check_nonmatching_packages(fatal=>0);
+# For update tests, let's do the update package info log stuff,
+# it may be useful for diagnosing the cause of the failure
+advisory_get_installed_packages;
+advisory_check_nonmatching_packages(fatal => 0);
 
 1;
 

--- a/lib/modularity.pm
+++ b/lib/modularity.pm
@@ -11,7 +11,7 @@ use utils;
 our @EXPORT = qw(parse_module_list is_listed);
 
 # This subroutine takes the output from the dnf module list command
-# and deletes all unnecessary stuff and returns an array of hash 
+# and deletes all unnecessary stuff and returns an array of hash
 # references where each hash consists of (module, stream, profile).
 # The subroutine only recognizes one profile but it is enough
 # for the sake of the modularity testing.
@@ -37,7 +37,7 @@ sub parse_module_list {
 sub is_listed {
     my ($module, $stream, $listref) = @_;
     my $found = 0;
-    foreach (@{ $listref }) {
+    foreach (@{$listref}) {
         if ($_->{module} eq $module and $_->{stream} eq $stream) {
             $found = 1;
         }

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -22,9 +22,9 @@ sub run_with_error_check {
         # by using 'unless' and 'expect_not_found=>1' here we avoid
         # the web UI showing each failure to see the error message as
         # a 'failed match'
-        die "Error screen appeared" unless (wait_serial($error_screen, timeout=>5, expect_not_found=>1));
+        die "Error screen appeared" unless (wait_serial($error_screen, timeout => 5, expect_not_found => 1));
         $func->();
-        die "Error screen appeared" unless (wait_serial($error_screen, timeout=>5, expect_not_found=>1));
+        die "Error screen appeared" unless (wait_serial($error_screen, timeout => 5, expect_not_found => 1));
     }
     else {
         die "Error screen appeared" if (check_screen $error_screen, 5);
@@ -40,7 +40,7 @@ sub type_safely {
     type_string($string, wait_screen_change => 3, max_interval => 20);
     # similarity level 45 as there will commonly be a flashing
     # cursor and the default level (47) is slightly too tight
-    wait_still_screen(stilltime=>2, similarity_level=>45);
+    wait_still_screen(stilltime => 2, similarity_level => 45);
 }
 
 # high-level 'type this string extremely safely and rather slow'
@@ -50,7 +50,7 @@ sub type_very_safely {
     type_string($string, wait_screen_change => 1, max_interval => 1);
     # similarity level 45 as there will commonly be a flashing
     # cursor and the default level (47) is slightly too tight
-    wait_still_screen(stilltime=>5, similarity_level=>45);
+    wait_still_screen(stilltime => 5, similarity_level => 45);
 }
 
 sub get_release_number {
@@ -60,13 +60,13 @@ sub get_release_number {
     my $version = get_var("VERSION");
     my $rawrel = get_var("RAWREL", "Rawhide");
     return $rawrel if ($version eq "Rawhide");
-    return $version
+    return $version;
 }
 
 sub get_version_major {
-  my $version = get_var('VERSION');
-  my $version_major = substr($version, 0, index($version, q/./));
-  return $version_major
+    my $version = get_var('VERSION');
+    my $version_major = substr($version, 0, index($version, q/./));
+    return $version_major;
 }
 
 sub get_code_name {
@@ -74,11 +74,11 @@ sub get_code_name {
     my $version = get_var('VERSION');
     my $version_major = get_version_major;
 
-    given($version_major){
-        when ('9') {  $code_name = 'Blue Onyx'; }
-        when ('10') {  $code_name = 'Smoky Quartz'; }
-        when ('11') {  $code_name = 'Lavender Calcite'; }
-        default{
+    given ($version_major) {
+        when ('9') { $code_name = 'Blue Onyx'; }
+        when ('10') { $code_name = 'Smoky Quartz'; }
+        when ('11') { $code_name = 'Lavender Calcite'; }
+        default {
             $code_name = 'Green Obsidian';
         }
     }
@@ -98,9 +98,9 @@ sub desktop_vt {
     # stop as soon as any command fails, so we use ||: to make the
     # first grep return 0 even if it matches nothing
     eval { $xout = script_output ' loginctl | grep test ||:; ps -e | egrep "(gnome-session|Xwayland|Xorg)" | grep -o tty[0-9]' };
-    my $tty = 1; # default
+    my $tty = 1;    # default
     while ($xout =~ /tty(\d)/g) {
-        $tty = $1; # most recent match is probably best
+        $tty = $1;    # most recent match is probably best
     }
     send_key "ctrl-alt-f${tty}";
     # work around https://gitlab.gnome.org/GNOME/gnome-software/issues/582
@@ -129,7 +129,7 @@ sub boot_to_login_screen {
     $args{timeout} //= 300;
     if (testapi::is_serial_terminal) {
         # For serial console, just wait for the login prompt
-        unless (wait_serial "login:", timeout=>$args{timeout}) {
+        unless (wait_serial "login:", timeout => $args{timeout}) {
             die "No login prompt shown on serial console.";
         }
     }
@@ -140,14 +140,14 @@ sub boot_to_login_screen {
         # The following is true for non-serial console.
         my $count = 5;
         while (check_screen("login_screen", 3) && $count > 0) {
-           sleep 5;
-           $count -= 1;
+            sleep 5;
+            $count -= 1;
         }
-       assert_screen "login_screen", $args{timeout};
-       if (match_has_tag "graphical_login") {
-           wait_still_screen 10, 30;
-           assert_screen "login_screen";
-       }
+        assert_screen "login_screen", $args{timeout};
+        if (match_has_tag "graphical_login") {
+            wait_still_screen 10, 30;
+            assert_screen "login_screen";
+        }
     }
 }
 
@@ -174,7 +174,7 @@ sub desktop_switch_layout {
     # if already selected, we're good
     return if (check_screen "${environment}_layout_${layout}", 3);
     # otherwise we need to switch
-    my $switcher = "alt-shift";  # anaconda
+    my $switcher = "alt-shift";    # anaconda
     $switcher = "super-spc" if $environment eq 'gnome';
     # KDE? not used yet
     send_key $switcher;
@@ -188,7 +188,7 @@ sub desktop_switch_layout {
 sub _console_login_finish {
     # The check differs according to the console used.
     if (testapi::is_serial_terminal) {
-        unless (wait_serial("-bash-.*[#\$]", timeout=>5, expect_not_found=>1)) {
+        unless (wait_serial("-bash-.*[#\$]", timeout => 5, expect_not_found => 1)) {
             record_soft_failure "It looks like profile sourcing failed";
         }
     }
@@ -219,7 +219,7 @@ sub console_login {
     # enable a new proper login based on the user variable.
     if (get_var("SERIAL_CONSOLE")) {
         # Check for the usual prompt.
-        if (wait_serial("~\][#\$]", timeout=>5, quiet=>1)) {
+        if (wait_serial("~\][#\$]", timeout => 5, quiet => 1)) {
             type_string "logout\n";
             # Wait a bit to let the logout properly finish.
             sleep 10;
@@ -233,7 +233,7 @@ sub console_login {
         # Let's perform a simple login test. This is the same as
         # whoami, but has the advantage of existing in installer env
         assert_script_run "id -un";
-        unless (wait_serial $args{user}, timeout=>5) {
+        unless (wait_serial $args{user}, timeout => 5) {
             die "Logging onto the serial console has failed.";
         }
     }
@@ -392,8 +392,8 @@ sub do_bootloader {
         # in SLOF usb-xhci driver failed sometimes in powerpc
         type_safely " $args{params}";
     }
-    save_screenshot; # for debug purpose
-    # ctrl-X boots from grub editor mode
+    save_screenshot;    # for debug purpose
+                        # ctrl-X boots from grub editor mode
     send_key "ctrl-x";
     # return boots all other cases
     send_key "ret";
@@ -515,7 +515,7 @@ sub _repo_setup_compose {
     assert_script_run 'dnf config-manager --set-disabled updates-testing updates';
     # script_run returns the exit code, so 'unless' here means 'if the file exists'
     unless (script_run 'test -f /etc/yum.repos.d/fedora-updates-modular.repo') {
-            assert_script_run 'dnf config-manager --set-disabled updates-testing-modular updates-modular';
+        assert_script_run 'dnf config-manager --set-disabled updates-testing-modular updates-modular';
     }
     # we use script_run here as the rawhide and modular repo files
     # won't always exist and we don't want to bother testing or
@@ -525,9 +525,9 @@ sub _repo_setup_compose {
     script_run "sed -i -e 's,^metalink,#metalink,g' -e 's,^mirrorlist,#mirrorlist,g' -e 's,^#baseurl.*basearch,baseurl=${location}/Modular/\$basearch,g' -e 's,^#baseurl.*source,baseurl=${location}/Modular/source,g' /etc/yum.repos.d/{fedora-modular,fedora-rawhide-modular}.repo", 0;
 
     # this can be used for debugging if something is going wrong
-#    unless (script_run 'pushd /etc/yum.repos.d && tar czvf yumreposd.tar.gz * && popd') {
-#        upload_logs "/etc/yum.repos.d/yumreposd.tar.gz";
-#    }
+    #    unless (script_run 'pushd /etc/yum.repos.d && tar czvf yumreposd.tar.gz * && popd') {
+    #        upload_logs "/etc/yum.repos.d/yumreposd.tar.gz";
+    #    }
 }
 
 sub _repo_setup_updates {
@@ -538,9 +538,9 @@ sub _repo_setup_updates {
     my $currrel = get_var("CURRREL", "0");
     repos_mirrorlist();
     # this can be used for debugging repo config if something is wrong
-#    unless (script_run 'pushd /etc/yum.repos.d && tar czvf yumreposd.tar.gz * && popd') {
-#        upload_logs "/etc/yum.repos.d/yumreposd.tar.gz";
-#    }
+    #    unless (script_run 'pushd /etc/yum.repos.d && tar czvf yumreposd.tar.gz * && popd') {
+    #        upload_logs "/etc/yum.repos.d/yumreposd.tar.gz";
+    #    }
     if ($version > $currrel) {
         # Disable updates-testing so other bad updates don't break us
         # this will do nothing on upgrade tests as we're on a stable
@@ -651,11 +651,11 @@ sub console_initial_setup {
     # Set timezone
     type_string "2\n";
     wait_still_screen 5;
-    type_string "1\n"; # Set timezone
+    type_string "1\n";    # Set timezone
     wait_still_screen 5;
-    type_string "1\n"; # Europe
+    type_string "1\n";    # Europe
     wait_still_screen 5;
-    type_string "37\n"; # Prague
+    type_string "37\n";    # Prague
     wait_still_screen 7;
 
     # Set root password
@@ -671,14 +671,14 @@ sub console_initial_setup {
     # Create user
     type_string "5\n";
     wait_still_screen 5;
-    type_string "1\n"; # create new
+    type_string "1\n";    # create new
     wait_still_screen 5;
-    type_string "3\n"; # set username
+    type_string "3\n";    # set username
     wait_still_screen 5;
     type_string get_var("USER_LOGIN", "test");
     send_key "ret";
     wait_still_screen 5;
-    type_string "5\n"; # set password
+    type_string "5\n";    # set password
     wait_still_screen 5;
     type_string get_var("USER_PASSWORD", "weakpassword");
     send_key "ret";
@@ -686,13 +686,13 @@ sub console_initial_setup {
     type_string get_var("USER_PASSWORD", "weakpassword");
     send_key "ret";
     wait_still_screen 5;
-    type_string "6\n"; # make him an administrator
+    type_string "6\n";    # make him an administrator
     wait_still_screen 5;
     type_string "c\n";
     wait_still_screen 7;
 
     assert_screen "console_initial_SETUP_DONE", 30;
-    type_string "c\n"; # continue
+    type_string "c\n";    # continue
 }
 
 sub handle_welcome_screen {
@@ -735,18 +735,18 @@ sub gnome_initial_setup {
         # https://fedoraproject.org//wiki/Changes/ReduceInitialSetupRedundancy
         # https://bugzilla.redhat.com/show_bug.cgi?id=1474787 ,
         # except 'language' is never *really* skipped (see above)
-        @nexts = grep {$_ ne 'keyboard'} @nexts;
-        @nexts = grep {$_ ne 'timezone'} @nexts;
+        @nexts = grep { $_ ne 'keyboard' } @nexts;
+        @nexts = grep { $_ ne 'timezone' } @nexts;
     }
     else {
         # 'timezone' and 'software' are suppressed for the 'existing user'
         # form of g-i-s
-        @nexts = grep {$_ ne 'software'} @nexts;
-        @nexts = grep {$_ ne 'timezone'} @nexts;
+        @nexts = grep { $_ ne 'software' } @nexts;
+        @nexts = grep { $_ ne 'timezone' } @nexts;
     }
     # 'additional software sources' screen does not display on F28+:
     # https://bugzilla.gnome.org/show_bug.cgi?id=794825
-    @nexts = grep {$_ ne 'software'} @nexts;
+    @nexts = grep { $_ ne 'software' } @nexts;
 
     # note: in g-i-s 3.37.91 and later, the first screen in systemwide
     # mode has a "Start Setup" button, not a "Next" button
@@ -761,13 +761,13 @@ sub gnome_initial_setup {
     # wait a bit in case of animation
     wait_still_screen 3;
     # one more check for frickin auth_required
-   if (check_screen "auth_required") {
+    if (check_screen "auth_required") {
         record_soft_failure "Unexpected authentication required: https://gitlab.gnome.org/GNOME/gnome-initial-setup/-/issues/106";
         send_key "esc";
     }
     # GDM 3.24.1 dumps a cursor in the middle of the screen here...
     mouse_hide if ($args{prelogin});
-    for my $n (1..scalar(@nexts)) {
+    for my $n (1 .. scalar(@nexts)) {
         # click 'Next' $nexts times, moving the mouse to avoid
         # highlight problems, sleeping to give it time to get
         # to the next screen between clicks
@@ -794,7 +794,7 @@ sub gnome_initial_setup {
     unless (get_var("VNC_CLIENT")) {
         # click 'Skip' one time (this is the 'goa' screen). We don't
         # get it on VNC_CLIENT case as network isn't working (yet)
-        mouse_set(100,100);
+        mouse_set(100, 100);
         wait_screen_change { assert_and_click "skip_button"; };
     }
     send_key "ret";
@@ -843,7 +843,7 @@ sub anaconda_create_user {
         @_
     );
     my $user_login = get_var("USER_LOGIN") || "test";
-    assert_and_click("anaconda_install_user_creation", timeout=>$args{timeout});
+    assert_and_click("anaconda_install_user_creation", timeout => $args{timeout});
     assert_screen "anaconda_install_user_creation_screen";
     # wait out animation
     wait_still_screen 2;
@@ -901,21 +901,21 @@ sub check_desktop {
 }
 
 sub download_modularity_tests {
-# Download the modularity test script, place in the system and then
-# modify the access rights to make it executable.
+    # Download the modularity test script, place in the system and then
+    # modify the access rights to make it executable.
     my ($whitelist) = @_;
     # we need python3-yaml for the script to run
     assert_script_run 'dnf -y install python3-yaml', 180;
     assert_script_run 'curl -o /root/test.py https://pagure.io/fedora-qa/modularity_testing_scripts/raw/master/f/modular_functions.py';
     if ($whitelist eq 'whitelist') {
-	assert_script_run 'curl -o /root/whitelist https://pagure.io/fedora-qa/modularity_testing_scripts/raw/master/f/whitelist';
+        assert_script_run 'curl -o /root/whitelist https://pagure.io/fedora-qa/modularity_testing_scripts/raw/master/f/whitelist';
     }
     assert_script_run 'chmod 755 /root/test.py';
 }
 
 sub quit_firefox {
-# Quit Firefox, handling the 'close multiple tabs' warning screen if
-# it shows up
+    # Quit Firefox, handling the 'close multiple tabs' warning screen if
+    # it shows up
     send_key "ctrl-q";
     # expect to get to either the tabs warning or a console
     if (check_screen ["user_console", "root_console", "firefox_close_tabs"], 30) {
@@ -927,14 +927,14 @@ sub quit_firefox {
 }
 
 sub start_with_launcher {
-# Get the name of the needle with a launcher, find the launcher in the menu
-# and click on it to start the application. This function works for the
-# Gnome desktop.
+    # Get the name of the needle with a launcher, find the launcher in the menu
+    # and click on it to start the application. This function works for the
+    # Gnome desktop.
 
     # $launcher holds the launcher needle, but some of the apps are hidden in a submenu
     # so this must be handled first to find the launcher needle.
 
-    my ($launcher,$submenu,$group) = @_;
+    my ($launcher, $submenu, $group) = @_;
     $submenu //= '';
     $group //= '';
     my $desktop = get_var('DESKTOP');
@@ -979,7 +979,7 @@ sub start_with_launcher {
         assert_and_click $launcher;
         wait_still_screen 5;
     }
-    elsif ($desktop eq 'kde'){
+    elsif ($desktop eq 'kde') {
         # Click on the KDE launcher icon
         assert_and_click 'kde_menu_launcher';
         wait_still_screen 2;
@@ -1006,7 +1006,7 @@ sub start_with_launcher {
 
 
 sub quit_with_shortcut {
-# Quit the application using the Alt-F4 keyboard shortcut
+    # Quit the application using the Alt-F4 keyboard shortcut
     send_key 'alt-f4';
     wait_still_screen 5;
     assert_screen 'workspace';
@@ -1035,12 +1035,12 @@ sub advisory_get_installed_packages {
         # occasionally, for some reason, it's unhappy about sorting;
         # we shouldn't fail the test in this case, just upload the
         # files so we can see why...
-        upload_logs "/tmp/allpkgs.txt", failok=>1;
-        upload_logs "/var/log/updatepkgs.txt", failok=>1;
+        upload_logs "/tmp/allpkgs.txt", failok => 1;
+        upload_logs "/var/log/updatepkgs.txt", failok => 1;
     }
     # we'll try and upload the output even if comm 'failed', as it
     # does in fact still write it in some cases
-    upload_logs "/var/log/testedpkgs.txt", failok=>1;
+    upload_logs "/var/log/testedpkgs.txt", failok => 1;
 }
 
 sub advisory_check_nonmatching_packages {
@@ -1068,8 +1068,8 @@ sub advisory_check_nonmatching_packages {
     script_run 'for pkg in $(cat /var/log/updatepkgnames.txt); do rpm -q $pkg && rpm -q $pkg --last | head -1 | cut -d" " -f1 | xargs rpm -q --qf "%{SOURCERPM} %{EPOCH} %{NAME}-%{VERSION}-%{RELEASE}\n" >> /tmp/installedupdatepkgs.txt; done';
     script_run 'sort -u -o /tmp/installedupdatepkgs.txt /tmp/installedupdatepkgs.txt';
     # for debugging, may as well always upload these, can't hurt anything
-    upload_logs "/tmp/installedupdatepkgs.txt", failok=>1;
-    upload_logs "/var/log/updatepkgs.txt", failok=>1;
+    upload_logs "/tmp/installedupdatepkgs.txt", failok => 1;
+    upload_logs "/var/log/updatepkgs.txt", failok => 1;
     # if any line appears in installedupdatepkgs.txt but not updatepkgs.txt,
     # we have a problem.
     if (script_run 'comm -23 /tmp/installedupdatepkgs.txt /var/log/updatepkgs.txt > /var/log/installednotupdatedpkgs.txt') {
@@ -1081,7 +1081,7 @@ sub advisory_check_nonmatching_packages {
     # this exits 1 if the file is zero-length, 0 if it's longer
     # if it's 0, that's *BAD*: we want to upload the file and fail
     unless (script_run 'test -s /var/log/installednotupdatedpkgs.txt') {
-        upload_logs "/var/log/installednotupdatedpkgs.txt", failok=>1;
+        upload_logs "/var/log/installednotupdatedpkgs.txt", failok => 1;
         my $message = "Package(s) from update not installed when it should have been! See installednotupdatedpkgs.txt";
         if ($args{fatal}) {
             set_var("_ACNMP_DONE", "1");
@@ -1134,7 +1134,7 @@ sub select_rescue_mode {
         }
     }
 
-    assert_screen "rescue_select", 180; # it takes time to start anaconda
+    assert_screen "rescue_select", 180;    # it takes time to start anaconda
 }
 
 sub copy_devcdrom_as_isofile {
@@ -1289,10 +1289,10 @@ sub check_prerelease {
         assert_screen "prerelease_note";
     }
     elsif ($prerelease == 0) {
-       # If the prerelease note is shown, where it should not be, die!
-       if (check_screen "prerelease_note") {
+        # If the prerelease note is shown, where it should not be, die!
+        if (check_screen "prerelease_note") {
             die "The PRERELEASE tag is shown, but it should NOT be.";
-       }
+        }
     }
 }
 
@@ -1372,12 +1372,12 @@ sub click_unwanted_notifications {
     my @closed;
     while ($count > 0 && check_screen "desktop_update_notification_popup", 5) {
         $count -= 1;
-        push (@closed, 'update');
+        push(@closed, 'update');
         click_lastmatch;
     }
     if (check_screen "akonadi_migration_agent_running", 5) {
         click_lastmatch;
-        push (@closed, 'akonadi');
+        push(@closed, 'akonadi');
     }
     return @closed;
 }
@@ -1400,7 +1400,7 @@ sub register_application {
 sub solidify_wallpaper {
     my $desktop = get_var("DESKTOP");
     if ($desktop eq "kde") {
-    # Run the Desktop settings
+        # Run the Desktop settings
         # FIXME workaround a weird bug where alt-d-s does something
         # different until you right click on the desktop:
         # https://bugzilla.redhat.com/show_bug.cgi?id=1933118

--- a/main.pm
+++ b/main.pm
@@ -33,7 +33,7 @@ testapi::set_distribution(fedoradistribution->new());
 # Stolen from openSUSE.
 sub unregister_needle_tags($) {
     my $tag = shift;
-    my @a   = @{ needle::tags($tag) };
+    my @a = @{needle::tags($tag)};
     for my $n (@a) { $n->unregister(); }
 }
 
@@ -49,14 +49,14 @@ sub unregister_needle_tags($) {
 # 'LANGUAGE-' at all.
 sub unregister_prefix_tags {
     my ($prefix, $valueref) = @_;
-    NEEDLE: for my $needle ( needle::all() ) {
+  NEEDLE: for my $needle (needle::all()) {
         my $unregister = 0;
-        for my $tag ( @{$needle->{'tags'}} ) {
+        for my $tag (@{$needle->{'tags'}}) {
             if ($tag =~ /^\Q$prefix/) {
                 # We have at least one tag matching the prefix, so we
                 # *MAY* want to un-register the needle
                 $unregister = 1;
-                for my $value ( @{$valueref} ) {
+                for my $value (@{$valueref}) {
                     # At any point if we hit a prefix-value match, we
                     # know we need to keep this needle and can skip
                     # to the next
@@ -85,13 +85,13 @@ sub cleanup_needles() {
 
     # Unregister desktop needles of other desktops when DESKTOP is specified
     if (get_var('DESKTOP')) {
-        unregister_prefix_tags('DESKTOP', [ get_var('DESKTOP') ])
+        unregister_prefix_tags('DESKTOP', [get_var('DESKTOP')]);
     }
 
     # Unregister non-language-appropriate needles. See unregister_except_
     # tags for details; basically all needles with at least one LANGUAGE-
     # tag will be unregistered unless they match the current langauge.
-    my $langref = [ get_var('LANGUAGE') || 'english' ];
+    my $langref = [get_var('LANGUAGE') || 'english'];
     unregister_prefix_tags('LANGUAGE', $langref);
 }
 $needle::cleanuphandler = \&cleanup_needles;
@@ -195,15 +195,15 @@ sub load_install_tests() {
     my $partitioning = get_var('PARTITIONING');
     # if PARTITIONING is unset, or one of [...], use disk_guided_empty,
     # which is the simplest / 'default' case.
-    if (! $partitioning || $partitioning ~~ ['guided_empty', 'guided_free_space']) {
+    if (!$partitioning || $partitioning ~~ ['guided_empty', 'guided_free_space']) {
         $storage = "tests/disk_guided_empty.pm";
     }
     else {
-        $storage = "tests/disk_".$partitioning.".pm";
+        $storage = "tests/disk_" . $partitioning . ".pm";
     }
     autotest::loadtest $storage;
 
-    if (get_var("ENCRYPT_PASSWORD")){
+    if (get_var("ENCRYPT_PASSWORD")) {
         autotest::loadtest "tests/disk_guided_encrypted.pm";
     }
 
@@ -330,7 +330,7 @@ sub load_postinstall_tests() {
     }
     autotest::loadtest $storagepost if ($storagepost);
 
-    if (get_var("UEFI") &! get_var("NO_UEFI_POST") &! get_var("START_AFTER_TEST")) {
+    if (get_var("UEFI") & !get_var("NO_UEFI_POST") & !get_var("START_AFTER_TEST")) {
         autotest::loadtest "tests/uefi_postinstall.pm";
     }
 

--- a/tests/_advisory_post.pm
+++ b/tests/_advisory_post.pm
@@ -5,7 +5,7 @@ use utils;
 
 sub run {
     my $self = shift;
-    $self->root_console(tty=>3);
+    $self->root_console(tty => 3);
     # figure out which packages from the update actually got installed
     # (if any) as part of this test
     advisory_get_installed_packages;
@@ -15,7 +15,7 @@ sub run {
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/_advisory_update.pm
+++ b/tests/_advisory_update.pm
@@ -7,7 +7,7 @@ sub run {
     my $self = shift;
     # do the 'repo setup' steps, which set up a repo containing the
     # update packages and run 'dnf update'
-    $self->root_console(tty=>3);
+    $self->root_console(tty => 3);
     repo_setup;
     if (get_var("ADVISORY_BOOT_TEST")) {
         # to test boot stuff - in case the update touched grub2, or dracut,
@@ -25,7 +25,7 @@ sub run {
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/_anaconda_kdump_disable.pm
+++ b/tests/_anaconda_kdump_disable.pm
@@ -7,7 +7,7 @@ use tapnet;
 sub run {
     my $self = shift;
     # Anaconda hub
-    assert_screen "anaconda_main_hub", 300; #
+    assert_screen "anaconda_main_hub", 300;    #
 
     assert_and_click "anaconda_main_hub_kdump";
     assert_and_click "anaconda_kdump_disable";
@@ -16,7 +16,7 @@ sub run {
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/_anaconda_kdump_enable.pm
+++ b/tests/_anaconda_kdump_enable.pm
@@ -7,7 +7,7 @@ use tapnet;
 sub run {
     my $self = shift;
     # Anaconda hub
-    assert_screen "anaconda_main_hub", 300; #
+    assert_screen "anaconda_main_hub", 300;    #
 
     assert_and_click "anaconda_main_hub_kdump";
     assert_and_click "anaconda_kdump_enable";
@@ -16,7 +16,7 @@ sub run {
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/_anaconda_network_enable.pm
+++ b/tests/_anaconda_network_enable.pm
@@ -7,7 +7,7 @@ use tapnet;
 sub run {
     my $self = shift;
     # Anaconda hub
-    assert_screen "anaconda_main_hub", 300; #
+    assert_screen "anaconda_main_hub", 300;    #
 
     if (check_screen ["anaconda_network_connected"], 60) {
         # network is connected already, we're done
@@ -22,7 +22,7 @@ sub run {
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/_anaconda_network_static.pm
+++ b/tests/_anaconda_network_static.pm
@@ -30,7 +30,7 @@ sub run {
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/_boot_to_anaconda.pm
+++ b/tests/_boot_to_anaconda.pm
@@ -77,7 +77,7 @@ sub run {
     # call do_bootloader with postinstall=0, the params, and the mutex,
     # unless we're a VNC install client (no bootloader there)
     unless (get_var("VNC_CLIENT")) {
-        do_bootloader(postinstall=>0, params=>$params, mutex=>$mutex, timeout=>$timeout);
+        do_bootloader(postinstall => 0, params => $params, mutex => $mutex, timeout => $timeout);
     }
 
     # Read variables for identification tests (see further).
@@ -99,7 +99,7 @@ sub run {
                 # we direct the installer to virtio-console1, and use
                 # virtio-console as a root console
                 select_console('virtio-console1');
-                unless (wait_serial "Use text mode", timeout=>120) { die "Anaconda has not started."; }
+                unless (wait_serial "Use text mode", timeout => 120) { die "Anaconda has not started."; }
                 type_string "2\n";
                 unless (wait_serial "Installation") { die "Text version of Anaconda has not started."; }
             }
@@ -130,17 +130,17 @@ sub run {
                 my $relnum = get_release_number;
                 my $dclick = 0;
                 $dclick = 1 if (get_var("DESKTOP") eq "kde" && $relnum > 33);
-                assert_and_click("live_start_anaconda_icon", dclick=>$dclick);
+                assert_and_click("live_start_anaconda_icon", dclick => $dclick);
                 unless (check_screen "anaconda_select_install_lang", 180) {
                     # click it again - on KDE since 2019-10 or so it seems
                     # like the first attempt sometimes just doesn't work
-                    assert_and_click("live_start_anaconda_icon", dclick=>$dclick, timeout=>300);
+                    assert_and_click("live_start_anaconda_icon", dclick => $dclick, timeout => 300);
                 }
             }
             my $language = get_var('LANGUAGE') || 'english';
             # wait for anaconda to appear; we click to work around
             # RHBZ #1566066 if it happens
-            assert_and_click("anaconda_select_install_lang", timeout=>300);
+            assert_and_click("anaconda_select_install_lang", timeout => 300);
 
             # Select install language
             wait_screen_change { assert_and_click "anaconda_select_install_lang_input"; };
@@ -177,7 +177,7 @@ sub run {
             # Here, we will watch for the graphical elements in Anaconda main hub.
             my $branched = get_var('VERSION');
             if ($identification eq 'true' or $branched ne "Rawhide") {
-                check_left_bar(); # See utils.pm
+                check_left_bar();    # See utils.pm
                 check_prerelease();
                 check_version();
             }
@@ -185,13 +185,13 @@ sub run {
             # didn't match anything: if the Rawhide warning didn't
             # show by now it never will, so we'll just wait for the
             # hub to show up.
-            assert_screen "anaconda_main_hub", 900; #
+            assert_screen "anaconda_main_hub", 900;    #
         }
     }
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/_check_install_source.pm
+++ b/tests/_check_install_source.pm
@@ -81,16 +81,16 @@ sub run {
     }
     # just for convenience - sometimes it's useful to see this log
     # for a success case
-    upload_logs "/tmp/packaging.log", failok=>1;
+    upload_logs "/tmp/packaging.log", failok => 1;
     send_key "ctrl-alt-f6";
 
     # Anaconda hub
-    assert_screen "anaconda_main_hub", 30; #
+    assert_screen "anaconda_main_hub", 30;    #
 
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/_collect_data.pm
+++ b/tests/_collect_data.pm
@@ -4,7 +4,7 @@ use testapi;
 
 sub run {
     my $self = shift;
-    $self->root_console(tty=>4);
+    $self->root_console(tty => 4);
     assert_script_run 'top -i -n20 -b > /var/tmp/top.log', 120;
     upload_logs '/var/tmp/top.log';
     unless (get_var("CANNED")) {
@@ -43,7 +43,7 @@ sub run {
 }
 
 sub test_flags {
-    return { 'ignore_failure' => 1 };
+    return {'ignore_failure' => 1};
 }
 
 1;

--- a/tests/_console_avc_crash.pm
+++ b/tests/_console_avc_crash.pm
@@ -5,7 +5,7 @@ use testapi;
 
 sub run {
     my $self = shift;
-    $self->root_console(tty=>3);
+    $self->root_console(tty => 3);
     # if this is a non-English, non-switched layout, load US layout
     # at this point
     # FIXME: this is all kind of a mess, as on such configs we need

--- a/tests/_console_login.pm
+++ b/tests/_console_login.pm
@@ -11,14 +11,14 @@ sub run {
     # with a password that requires Arabic support.
     # Such attempt to log in would always fail.
     if (get_var("LANGUAGE") ne "arabic" && get_var("USER_LOGIN") ne "false") {
-            console_login(user=>get_var("USER_LOGIN", "test"), password=>get_var("USER_PASSWORD", "weakpassword"));
+        console_login(user => get_var("USER_LOGIN", "test"), password => get_var("USER_PASSWORD", "weakpassword"));
     }
     if (get_var("ROOT_PASSWORD")) {
-        console_login(user=>"root", password=>get_var("ROOT_PASSWORD"));
+        console_login(user => "root", password => get_var("ROOT_PASSWORD"));
     }
 }
 sub test_flags {
-    return { fatal => 1, milestone => 1 };
+    return {fatal => 1, milestone => 1};
 }
 1;
 # vim: set sw=4 et:

--- a/tests/_console_shutdown.pm
+++ b/tests/_console_shutdown.pm
@@ -10,7 +10,7 @@ sub run {
     # use the desktops' graphical shutdown methods, we just go to a
     # console and run 'poweroff'. We can write separate tests for
     # properly testing shutdown/reboot/log out from desktops.
-    $self->root_console(tty=>4);
+    $self->root_console(tty => 4);
     # disable the hidden grub menu on Workstation, so post-install
     # tests that need to edit boot params will see it. Don't use
     # assert_script_run as this will fail when it's not set
@@ -23,7 +23,7 @@ sub run {
 # even if shutdown fails. we should have a separate test for shutdown/
 # logout/reboot stuff, might need some refactoring.
 sub test_flags {
-    return { 'norollback' => 1, 'ignore_failure' => 1 };
+    return {'norollback' => 1, 'ignore_failure' => 1};
 }
 
 1;

--- a/tests/_console_wait_login.pm
+++ b/tests/_console_wait_login.pm
@@ -11,7 +11,7 @@ sub run {
 
     # handle bootloader, if requested
     if (get_var("GRUB_POSTINSTALL")) {
-        do_bootloader(postinstall=>1, params=>get_var("GRUB_POSTINSTALL"), timeout=>$wait_time);
+        do_bootloader(postinstall => 1, params => get_var("GRUB_POSTINSTALL"), timeout => $wait_time);
         $wait_time = 240;
     }
 
@@ -24,23 +24,23 @@ sub run {
     boot_to_login_screen(timeout => $wait_time);
 
     # switch to TTY3 for both, graphical and console tests
-    $self->root_console(tty=>3);
+    $self->root_console(tty => 3);
 
     # do user login unless USER_LOGIN is set to string 'false'
     unless (get_var("USER_LOGIN") eq "false") {
         # this avoids us waiting 90 seconds for a # to show up
         my $origprompt = $testapi::distri->{serial_term_prompt};
         $testapi::distri->{serial_term_prompt} = '$ ';
-        console_login(user=>get_var("USER_LOGIN", "test"), password=>get_var("USER_PASSWORD", "weakpassword"));
+        console_login(user => get_var("USER_LOGIN", "test"), password => get_var("USER_PASSWORD", "weakpassword"));
         $testapi::distri->{serial_term_prompt} = $origprompt;
     }
     if (get_var("ROOT_PASSWORD")) {
-        console_login(user=>"root", password=>get_var("ROOT_PASSWORD"));
+        console_login(user => "root", password => get_var("ROOT_PASSWORD"));
     }
 }
 
 sub test_flags {
-    return { fatal => 1, milestone => 1 };
+    return {fatal => 1, milestone => 1};
 }
 
 1;

--- a/tests/_coreos_install.pm
+++ b/tests/_coreos_install.pm
@@ -12,7 +12,7 @@ sub run {
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/_do_install_and_reboot.pm
+++ b/tests/_do_install_and_reboot.pm
@@ -137,14 +137,14 @@ sub run {
     # there are various things we might have to do at a console here
     # before we actually reboot. let's figure them all out first...
     my @actions;
-    push (@actions, 'consoletty0') if (get_var("ARCH") eq "aarch64");
-    push (@actions, 'abrt') if (get_var("ABRT", '') eq "system");
-    push (@actions, 'rootpw') if (get_var("INSTALLER_NO_ROOT"));
-    push (@actions, 'stagingrepos') if (get_var("DNF_CONTENTDIR"));
+    push(@actions, 'consoletty0') if (get_var("ARCH") eq "aarch64");
+    push(@actions, 'abrt') if (get_var("ABRT", '') eq "system");
+    push(@actions, 'rootpw') if (get_var("INSTALLER_NO_ROOT"));
+    push(@actions, 'stagingrepos') if (get_var("DNF_CONTENTDIR"));
     # memcheck test doesn't need to reboot at all. Rebooting from GUI
     # for lives is unreliable. And if we're already doing something
     # else at a console, we may as well reboot from there too
-    push (@actions, 'reboot') if (!get_var("MEMCHECK") && (get_var("LIVE") || @actions));
+    push(@actions, 'reboot') if (!get_var("MEMCHECK") && (get_var("LIVE") || @actions));
     # our approach for taking all these actions doesn't work on VNC
     # installs, fortunately we don't need any of them in that case
     # yet, so for now let's just flush the list here if we're VNC
@@ -159,14 +159,14 @@ sub run {
     }
     # OK, if we're here, we got actions, so head to a console. Switch
     # to console after liveinst sometimes takes a while, so 30 secs
-    $self->root_console(timeout=>30);
+    $self->root_console(timeout => 30);
     # this is something a couple of actions may need to know
     my $mount = "/mnt/sysimage";
     if (get_var("CANNED")) {
         # finding the actual host system root is fun for ostree...
         $mount = "/mnt/sysimage/ostree/deploy/fedora*/deploy/*.?";
     }
-    if (grep {$_ eq 'consoletty0'} @actions) {
+    if (grep { $_ eq 'consoletty0' } @actions) {
         # somehow, by this point, localized keyboard layout has been
         # loaded for this tty, so for French and Arabic at least we
         # need to load the 'us' layout again for the next command to
@@ -180,15 +180,15 @@ sub run {
         # regenerate the bootloader config
         assert_script_run "chroot $mount grub2-mkconfig -o /boot/efi/EFI/rocky/grub.cfg";
     }
-    if (grep {$_ eq 'abrt'} @actions) {
-         # Chroot in the newly installed system and switch on ABRT systemwide
-         assert_script_run "chroot $mount abrt-auto-reporting 1";
+    if (grep { $_ eq 'abrt' } @actions) {
+        # Chroot in the newly installed system and switch on ABRT systemwide
+        assert_script_run "chroot $mount abrt-auto-reporting 1";
     }
-    if (grep {$_ eq 'rootpw'} @actions) {
+    if (grep { $_ eq 'rootpw' } @actions) {
         my $root_password = get_var("ROOT_PASSWORD") || "weakpassword";
         assert_script_run "echo 'root:$root_password' | chpasswd -R $mount";
     }
-    if (grep {$_ eq 'stagingrepos'} @actions) {
+    if (grep { $_ eq 'stagingrepos' } @actions) {
         if (get_version_major() < 9) {
             assert_script_run 'sed -i -e "s/^mirrorlist/#mirrorlist/g;s,^#\(baseurl=http[s]*://\),\1,g" ' . $mount . '/etc/yum.repos.d/Rocky-BaseOS.repo';
             assert_script_run 'sed -i -e "s/^mirrorlist/#mirrorlist/g;s,^#\(baseurl=http[s]*://\),\1,g" ' . $mount . '/etc/yum.repos.d/Rocky-AppStream.repo';
@@ -202,11 +202,11 @@ sub run {
         }
         assert_script_run 'printf "stg/rocky\n" > ' . $mount . '/etc/dnf/vars/contentdir';
     }
-    type_string "reboot\n" if (grep {$_ eq 'reboot'} @actions);
+    type_string "reboot\n" if (grep { $_ eq 'reboot' } @actions);
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/_graphical_input.pm
+++ b/tests/_graphical_input.pm
@@ -50,7 +50,7 @@ sub run {
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/_graphical_wait_login.pm
+++ b/tests/_graphical_wait_login.pm
@@ -17,17 +17,17 @@ sub run {
 
     # handle bootloader, if requested
     if (get_var("GRUB_POSTINSTALL")) {
-        do_bootloader(postinstall=>1, params=>get_var("GRUB_POSTINSTALL"), timeout=>$wait_time);
+        do_bootloader(postinstall => 1, params => get_var("GRUB_POSTINSTALL"), timeout => $wait_time);
         $wait_time = 300;
     }
 
     # Handle pre-login initial setup if we're doing INSTALL_NO_USER
     if (get_var("INSTALL_NO_USER") && !get_var("_SETUP_DONE")) {
         if (get_var("DESKTOP") eq 'gnome') {
-            gnome_initial_setup(prelogin=>1, timeout=>$wait_time);
+            gnome_initial_setup(prelogin => 1, timeout => $wait_time);
         }
         else {
-            anaconda_create_user(timeout=>$wait_time);
+            anaconda_create_user(timeout => $wait_time);
             # wait out animation
             wait_still_screen 3;
             assert_and_click "initialsetup_finish_configuration";
@@ -41,7 +41,7 @@ sub run {
     unless (get_var("DESKTOP") eq 'gnome' && get_var("INSTALL_NO_USER")) {
         unless (get_var("HDD_1") && !(get_var("PARTITIONING") eq "custom_resize_lvm")) {
             # in 9.0, license screens are not shown by default
-            # https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/9.0_release_notes/index#enhancement_installer-and-image-creation
+         # https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/9.0_release_notes/index#enhancement_installer-and-image-creation
             unless (get_version_major() > 8) {
                 # for Rocky Linux here happens to be a license acceptance screen
                 # the initial appearance can sometimes take really long
@@ -125,7 +125,7 @@ sub run {
         # root user now, for subsequent tests to work
         if (get_var("IMAGE_DEPLOY")) {
             send_key "ctrl-alt-f3";
-            console_login(user=>get_var("USER_LOGIN", "test"), password=>get_var("USER_PASSWORD", "weakpassword"));
+            console_login(user => get_var("USER_LOGIN", "test"), password => get_var("USER_PASSWORD", "weakpassword"));
             type_string "sudo su\n";
             type_string "$password\n";
             my $root_password = get_var("ROOT_PASSWORD") || "weakpassword";
@@ -137,11 +137,11 @@ sub run {
     # Move the mouse somewhere it won't highlight the match areas
     mouse_set(300, 800);
     # KDE can take ages to start up
-    check_desktop(timeout=>120);
+    check_desktop(timeout => 120);
 }
 
 sub test_flags {
-    return { fatal => 1, milestone => 1 };
+    return {fatal => 1, milestone => 1};
 }
 
 1;

--- a/tests/_installer_build.pm
+++ b/tests/_installer_build.pm
@@ -24,13 +24,13 @@ sub run {
     $cmd .= " --repo=/etc/yum.repos.d/advisory.repo --repo=/etc/yum.repos.d/workarounds.repo ./results";
     assert_script_run $cmd, 1500;
     # good to have the log around for checks
-    upload_logs "pylorax.log", failok=>1;
+    upload_logs "pylorax.log", failok => 1;
     assert_script_run "mv results/images/boot.iso ./${advortask}-netinst-${arch}.iso";
     upload_asset "./${advortask}-netinst-x86_64.iso";
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/_iot_zezere_remote.pm
+++ b/tests/_iot_zezere_remote.pm
@@ -56,7 +56,7 @@ sub run {
 
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/_iot_zezere_server.pm
+++ b/tests/_iot_zezere_server.pm
@@ -39,7 +39,7 @@ sub run {
 
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/_live_build.pm
+++ b/tests/_live_build.pm
@@ -66,7 +66,7 @@ sub run {
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/_memcheck.pm
+++ b/tests/_memcheck.pm
@@ -1,17 +1,17 @@
 use base "anacondatest";
- use strict;
- use testapi;
- 
- sub run {
-     my $self = shift;
-     $self->root_console();
-     upload_logs '/tmp/memory.dat';
- }
- 
- sub test_flags {
-     return { fatal => 1 };
- }
- 
- 1;
- 
- # vim: set sw=4 et:
+use strict;
+use testapi;
+
+sub run {
+    my $self = shift;
+    $self->root_console();
+    upload_logs '/tmp/memory.dat';
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;
+
+# vim: set sw=4 et:

--- a/tests/_podman_client.pm
+++ b/tests/_podman_client.pm
@@ -8,7 +8,7 @@ use utils;
 
 sub run {
     my $self = shift;
-    $self->root_console(tty=>3);
+    $self->root_console(tty => 3);
     # wait for server to be set up
     mutex_lock "podman_server_ready";
     mutex_unlock "podman_server_ready";
@@ -23,7 +23,7 @@ sub run {
 
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/_post_network_static.pm
+++ b/tests/_post_network_static.pm
@@ -13,7 +13,7 @@ sub run {
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/_setup_browser.pm
+++ b/tests/_setup_browser.pm
@@ -6,7 +6,7 @@ use utils;
 sub run {
     my $self = shift;
     # switch to TTY3 for both, graphical and console tests
-    $self->root_console(tty=>3);
+    $self->root_console(tty => 3);
 
     # set up appropriate repositories
     repo_setup();
@@ -27,7 +27,7 @@ sub run {
 }
 
 sub test_flags {
-    return { fatal => 1, milestone => 1 };
+    return {fatal => 1, milestone => 1};
 }
 
 1;

--- a/tests/_software_selection.pm
+++ b/tests/_software_selection.pm
@@ -5,7 +5,7 @@ use testapi;
 sub run {
     my $self = shift;
     # Anaconda hub
-    assert_screen "anaconda_main_hub", 300; #
+    assert_screen "anaconda_main_hub", 300;    #
 
     # Select package set.
     # If 'default' is specified, skip selection, but verify correct default
@@ -33,22 +33,22 @@ sub run {
 
     # In Rocky, graphical-server starts out selected in the DVD ISO so if that's
     # what we're looking for we're done
-    if (!check_screen("anaconda_".$packageset."_selected", 1)) {
-      send_key_until_needlematch("anaconda_".$packageset."_highlighted", "down", 20);
-      send_key "spc";
+    if (!check_screen("anaconda_" . $packageset . "_selected", 1)) {
+        send_key_until_needlematch("anaconda_" . $packageset . "_highlighted", "down", 20);
+        send_key "spc";
     }
 
     # check that desired environment is selected
-    assert_screen "anaconda_".$packageset."_selected";
+    assert_screen "anaconda_" . $packageset . "_selected";
     assert_and_click "anaconda_spoke_done";
 
     # Anaconda hub
-    assert_screen "anaconda_main_hub", 50; #
+    assert_screen "anaconda_main_hub", 50;    #
 
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/_staging_repos_disable.pm
+++ b/tests/_staging_repos_disable.pm
@@ -5,17 +5,17 @@ use utils;
 
 sub run {
     my $self = shift;
-    $self->root_console(tty=>4);
+    $self->root_console(tty => 4);
     # Point at default repositories by modifying contentdir
     # NOTE: This will leave repos pointing at primary dl server instead
     #       of mirrorlist.
     script_run 'printf "pub/rocky\n" > /etc/dnf/vars/contentdir';
     script_run 'dnf clean all';
-    script_run 'dnf repoinfo'
+    script_run 'dnf repoinfo';
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/_staging_repos_enable.pm
+++ b/tests/_staging_repos_enable.pm
@@ -5,14 +5,14 @@ use utils;
 
 sub run {
     my $self = shift;
-    $self->root_console(tty=>4);
+    $self->root_console(tty => 4);
     # Point at staging repositories by modifying contentdir
     if (get_version_major() < 9) {
         script_run "sed -i 's/^mirrorlist/#mirrorlist/g' /etc/yum.repos.d/Rocky-*";
         script_run "sed -i 's,^#\(baseurl=http[s]*://\),\1,g' /etc/yum.repos.d/Rocky-*";
     } else {
-      script_run "sed -i 's/^mirrorlist/#mirrorlist/g' /etc/yum.repos.d/rocky*";
-      script_run "sed -i 's,^#\(baseurl=http[s]*://\),\1,g' /etc/yum.repos.d/rocky*";
+        script_run "sed -i 's/^mirrorlist/#mirrorlist/g' /etc/yum.repos.d/rocky*";
+        script_run "sed -i 's,^#\(baseurl=http[s]*://\),\1,g' /etc/yum.repos.d/rocky*";
     }
     script_run 'printf "stg/rocky\n" > /etc/dnf/vars/contentdir';
     script_run 'dnf clean all';
@@ -20,7 +20,7 @@ sub run {
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/_support_server.pm
+++ b/tests/_support_server.pm
@@ -85,7 +85,7 @@ file:///ks.cfg\n  initrdefi rocky/initrd.img\n}' >> /var/lib/tftpboot/grub.cfg";
     # download kernel and initramfs
     my $location = get_var("LOCATION");
     my $kernpath = "images/pxeboot";
-        # for some crazy reason these are in a different place for ppc64
+    # for some crazy reason these are in a different place for ppc64
     $kernpath = "ppc/ppc64" if ($arch eq 'ppc64le');
     assert_script_run "curl -o /var/lib/tftpboot/rocky/vmlinuz $location/BaseOS/${arch}/os/${kernpath}/vmlinuz";
     assert_script_run "curl -o /var/lib/tftpboot/rocky/initrd.img $location/BaseOS/${arch}/os/${kernpath}/initrd.img";
@@ -104,7 +104,7 @@ file:///ks.cfg\n  initrdefi rocky/initrd.img\n}' >> /var/lib/tftpboot/grub.cfg";
 }
 
 sub run {
-    my $self=shift;
+    my $self = shift;
     # disable systemd-resolved, it conflicts with dnsmasq
     unless (script_run "systemctl is-active systemd-resolved.service") {
         script_run "systemctl stop systemd-resolved.service";
@@ -127,7 +127,7 @@ sub run {
     ## ISCSI
 
     # start up iscsi target
-    #assert_script_run "printf '<target iqn.2016-06.local.domain:support.target1>\n    backing-store /dev/vdb\n    incominguser test weakpassword\n</target>' > /etc/tgt/conf.d/openqa.conf";
+#assert_script_run "printf '<target iqn.2016-06.local.domain:support.target1>\n    backing-store /dev/vdb\n    incominguser test weakpassword\n</target>' > /etc/tgt/conf.d/openqa.conf";
     assert_script_run "targetcli /backstores/block create dev=/dev/vdb name=vdb";
     assert_script_run "targetcli /iscsi create wwn=iqn.2016-06.local.domain:support.target1";
     assert_script_run "targetcli /iscsi/iqn.2016-06.local.domain:support.target1/tpg1/acls create iqn.2016-06.local.domain:support.target1";
@@ -186,7 +186,7 @@ sub run {
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/_vnc_client_connect.pm
+++ b/tests/_vnc_client_connect.pm
@@ -20,7 +20,7 @@ sub run {
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/_vnc_client_connect_pre.pm
+++ b/tests/_vnc_client_connect_pre.pm
@@ -7,7 +7,7 @@ use utils;
 sub run {
     my $self = shift;
     boot_to_login_screen(timeout => 300);
-    $self->root_console(tty=>3);
+    $self->root_console(tty => 3);
     setup_tap_static('172.16.2.115', 'vnc002.test.openqa.fedoraproject.org');
     # test test: check if we can see the server
     assert_script_run "ping -c 2 172.16.2.114";
@@ -18,7 +18,7 @@ sub run {
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/_vncconnect_client_setup.pm
+++ b/tests/_vncconnect_client_setup.pm
@@ -13,7 +13,7 @@ sub run {
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/_vncconnect_client_setup_pre.pm
+++ b/tests/_vncconnect_client_setup_pre.pm
@@ -7,7 +7,7 @@ use utils;
 sub run {
     my $self = shift;
     boot_to_login_screen(timeout => 300);
-    $self->root_console(tty=>3);
+    $self->root_console(tty => 3);
     setup_tap_static('172.16.2.117', 'vnc004.test.openqa.fedoraproject.org');
     # install tigervnc (Boxes doesn't do reverse VNC)
     assert_script_run "dnf -y install tigervnc", 180;
@@ -17,7 +17,7 @@ sub run {
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/anaconda_help.pm
+++ b/tests/anaconda_help.pm
@@ -56,11 +56,11 @@ sub run {
     # on GNOME installs (Workstation Live and Silverblue) we don't
     # need to set a root password or create a user; on other flavors
     # we must
-    unless (get_var("DESKTOP") eq "gnome" ) {
+    unless (get_var("DESKTOP") eq "gnome") {
         # In Rocky ISO you will finish testplan on Create User and need to shift-tab to select
-	# Root password
-        if ((get_var("DISTRI") eq "rocky" )) {
-	    send_key_until_needlematch("anaconda_main_hub_root_password", "shift-tab");
+        # Root password
+        if ((get_var("DISTRI") eq "rocky")) {
+            send_key_until_needlematch("anaconda_main_hub_root_password", "shift-tab");
         }
         assert_and_click "anaconda_main_hub_root_password";
         type_safely "weakrootpassword";

--- a/tests/applications/evince/aaa_setup.pm
+++ b/tests/applications/evince/aaa_setup.pm
@@ -25,13 +25,13 @@ sub download_testdata {
     # Change ownership and attributes
     assert_script_run("chown -R test:test openqa_testdata");
     # Move the test file into a correct location.
-    assert_script_run("cp openqa_testdata/evince/evince.pdf Documents")
+    assert_script_run("cp openqa_testdata/evince/evince.pdf Documents");
 }
 
 sub run {
     my $self = shift;
     # Switch to console
-    $self->root_console(tty=>3);
+    $self->root_console(tty => 3);
     # Perform git test
     check_and_install_git();
     # Download the test data
@@ -55,7 +55,7 @@ sub run {
 
     # Select the evince.pdf file.
     assert_and_click("evince_file_select_pdf", button => "left", timeout => 30);
-    
+
     # Click the Open button to open the file
     assert_and_click("gnome_button_open", button => "left", timeout => 30);
 

--- a/tests/applications/evince/about.pm
+++ b/tests/applications/evince/about.pm
@@ -6,23 +6,23 @@ use utils;
 # This part of the suite tests if About works.
 
 sub run {
-my $self = shift;
+    my $self = shift;
 
-# Open the menu by clicking on the Burger icon
-assert_and_click("gnome_burger_menu", button => "left", timeout => 30);
-wait_still_screen 2;
+    # Open the menu by clicking on the Burger icon
+    assert_and_click("gnome_burger_menu", button => "left", timeout => 30);
+    wait_still_screen 2;
 
-# In the menu, select the About item.
-assert_and_click("evince_menu_about", button => "left", timeout => 30);
+    # In the menu, select the About item.
+    assert_and_click("evince_menu_about", button => "left", timeout => 30);
 
-# Check that the About section has been displayed.
-assert_screen("evince_about_shown");
+    # Check that the About section has been displayed.
+    assert_screen("evince_about_shown");
 
-# Click on Credits button to see the second part of the dialogue.
-assert_and_click("evince_about_credits", button => "left", timeout => 30);
+    # Click on Credits button to see the second part of the dialogue.
+    assert_and_click("evince_about_credits", button => "left", timeout => 30);
 
-# Check that Credits are accessible and visible, too.
-assert_screen("evince_credits_shown");
+    # Check that Credits are accessible and visible, too.
+    assert_screen("evince_credits_shown");
 
 }
 

--- a/tests/applications/evince/add_annotation.pm
+++ b/tests/applications/evince/add_annotation.pm
@@ -6,37 +6,37 @@ use utils;
 # This part of the suite tests an annotation can be added to the displayed content.
 
 sub run {
-my $self = shift;
+    my $self = shift;
 
-# Click on the Pencil button.
-assert_and_click("evince_add_annotation", button => "left", timeout => 30);
+    # Click on the Pencil button.
+    assert_and_click("evince_add_annotation", button => "left", timeout => 30);
 
-# Click on Note text.
-assert_and_click("evince_add_annotation_text", button => "left", timeout => 30);
+    # Click on Note text.
+    assert_and_click("evince_add_annotation_text", button => "left", timeout => 30);
 
-# Select location to add annotation.
-assert_and_click("evince_select_annotation_place", button => "left", timeout => 30);
+    # Select location to add annotation.
+    assert_and_click("evince_select_annotation_place", button => "left", timeout => 30);
 
-# Enter some text to the annotation.
-type_very_safely("Add note");
+    # Enter some text to the annotation.
+    type_very_safely("Add note");
 
-# Check that the annotation window has appeared with that text.
-assert_screen("evince_annotation_added");
+    # Check that the annotation window has appeared with that text.
+    assert_screen("evince_annotation_added");
 
-# Close the annotation.
-assert_and_click("evince_close_annotation", button => "left", timeout => 30);
+    # Close the annotation.
+    assert_and_click("evince_close_annotation", button => "left", timeout => 30);
 
-# Check that the annotation is still placed in the document.
-assert_screen("evince_annotation_placed");
+    # Check that the annotation is still placed in the document.
+    assert_screen("evince_annotation_placed");
 
-# Open the annotation's context menu.
-assert_and_click("evince_annotation_placed", button => "right", timeout => 30);
+    # Open the annotation's context menu.
+    assert_and_click("evince_annotation_placed", button => "right", timeout => 30);
 
-# Remove the annotation.
-assert_and_click("evince_remove_annotation", button => "left", timeout => 30);
+    # Remove the annotation.
+    assert_and_click("evince_remove_annotation", button => "left", timeout => 30);
 
-# Check that the annotation has been removed.
-assert_screen("evince_annotation_removed");
+    # Check that the annotation has been removed.
+    assert_screen("evince_annotation_removed");
 
 }
 

--- a/tests/applications/evince/change_zoom.pm
+++ b/tests/applications/evince/change_zoom.pm
@@ -6,22 +6,22 @@ use utils;
 # This part of the suite tests that Evince can change the zoom of the document.
 
 sub run {
-my $self = shift;
+    my $self = shift;
 
 
-# Click on zoom menu to open choices.
-assert_and_click("evince_change_zoom", button => "left", timeout => 30);
+    # Click on zoom menu to open choices.
+    assert_and_click("evince_change_zoom", button => "left", timeout => 30);
 
-# Select 200%.
-assert_and_click("evince_select_zoom_200", button => "left", timeout => 30);
+    # Select 200%.
+    assert_and_click("evince_select_zoom_200", button => "left", timeout => 30);
 
-# Check that the document zoom was changed.
-assert_screen("evince_document_zoom_200");
+    # Check that the document zoom was changed.
+    assert_screen("evince_document_zoom_200");
 
 }
 
 sub test_flags {
-        return {always_rollback => 1};
+    return {always_rollback => 1};
 }
 
 1;

--- a/tests/applications/evince/dual_mode.pm
+++ b/tests/applications/evince/dual_mode.pm
@@ -6,32 +6,32 @@ use utils;
 # This part of the suite tests that Evince is able to display content in a two-page mode.
 
 sub run {
-my $self = shift;
+    my $self = shift;
 
-# Click on the Zoom menu to change a different zoom for next steps.
-assert_and_click("evince_change_zoom", button => "left", timeout => 30);
+    # Click on the Zoom menu to change a different zoom for next steps.
+    assert_and_click("evince_change_zoom", button => "left", timeout => 30);
 
-# Select the Fit Width option to be able to see the whole layout.
-assert_and_click("evince_select_zoom_fitwidth", button => "left", timeout => 30);
+    # Select the Fit Width option to be able to see the whole layout.
+    assert_and_click("evince_select_zoom_fitwidth", button => "left", timeout => 30);
 
-#Dismiss the dialogue
-send_key("esc");
+    #Dismiss the dialogue
+    send_key("esc");
 
-# Enter the menu
-assert_and_click("gnome_burger_menu", button => "left", timeout => 30);
+    # Enter the menu
+    assert_and_click("gnome_burger_menu", button => "left", timeout => 30);
 
-# Select the Dual mode
-assert_and_click("evince_menu_dual", button => "left", timeout => 30);
+    # Select the Dual mode
+    assert_and_click("evince_menu_dual", button => "left", timeout => 30);
 
-# Dismiss the menu
-send_key("esc");
+    # Dismiss the menu
+    send_key("esc");
 
-# Check that the content is displayed in dual mode.
-assert_screen("evince_dual_mode", timeout => 30);
+    # Check that the content is displayed in dual mode.
+    assert_screen("evince_dual_mode", timeout => 30);
 }
 
 sub test_flags {
-        return {always_rollback => 1};
+    return {always_rollback => 1};
 }
 
 1;

--- a/tests/applications/evince/help.pm
+++ b/tests/applications/evince/help.pm
@@ -6,22 +6,22 @@ use utils;
 # This part of the suite tests that Evince can display the Help pages.
 
 sub run {
-my $self = shift;
+    my $self = shift;
 
-# Open menu with Burger icon.
-assert_and_click("gnome_burger_menu", button => "left", timeout => 30);
-wait_still_screen 2;
+    # Open menu with Burger icon.
+    assert_and_click("gnome_burger_menu", button => "left", timeout => 30);
+    wait_still_screen 2;
 
-# Select the Help item in the menu.
-assert_and_click("evince_menu_help", button => "left", timeout => 30);
-wait_still_screen 2;
+    # Select the Help item in the menu.
+    assert_and_click("evince_menu_help", button => "left", timeout => 30);
+    wait_still_screen 2;
 
-# Check that Help has been shown.
-assert_screen("evince_help_shown", timeout => 30);
+    # Check that Help has been shown.
+    assert_screen("evince_help_shown", timeout => 30);
 }
 
 sub test_flags {
-        return {always_rollback => 1};
+    return {always_rollback => 1};
 }
 
 1;

--- a/tests/applications/evince/night_mode.pm
+++ b/tests/applications/evince/night_mode.pm
@@ -6,25 +6,25 @@ use utils;
 # This part of the suite tests that Evince can be switched into night mode.
 
 sub run {
-my $self = shift;
+    my $self = shift;
 
-# Click on the Menu button.
-assert_and_click("gnome_burger_menu", timeout => 30, button => "left");
+    # Click on the Menu button.
+    assert_and_click("gnome_burger_menu", timeout => 30, button => "left");
 
-# Click on the Night mode to select it.
-assert_and_click("evince_toggle_night_mode", button => "left", timeout => 30);
+    # Click on the Night mode to select it.
+    assert_and_click("evince_toggle_night_mode", button => "left", timeout => 30);
 
-# The menu stays opened, so hit Esc to dismiss it.
-send_key("esc");
-wait_still_screen 2;
+    # The menu stays opened, so hit Esc to dismiss it.
+    send_key("esc");
+    wait_still_screen 2;
 
-# Check that night mode has been activated.
-assert_screen("evince_night_mode", timeout => 30);
+    # Check that night mode has been activated.
+    assert_screen("evince_night_mode", timeout => 30);
 
 }
 
 sub test_flags {
-        return {always_rollback => 1};
+    return {always_rollback => 1};
 }
 
 1;

--- a/tests/applications/evince/properties.pm
+++ b/tests/applications/evince/properties.pm
@@ -6,22 +6,22 @@ use utils;
 # This part of the suite tests that Evince can show Document Properties.
 
 sub run {
-my $self = shift;
+    my $self = shift;
 
-# Open the menu.
-assert_and_click("gnome_burger_menu", button => "left", timeout => 30);
-wait_still_screen 2;
+    # Open the menu.
+    assert_and_click("gnome_burger_menu", button => "left", timeout => 30);
+    wait_still_screen 2;
 
-# Select the Properties item.
-assert_and_click("evince_menu_properties", button => "left", timeout => 30);
-wait_still_screen 2;
+    # Select the Properties item.
+    assert_and_click("evince_menu_properties", button => "left", timeout => 30);
+    wait_still_screen 2;
 
-# Check that Properties are shown.
-assert_screen("evince_properties_shown", timeout => 30);
+    # Check that Properties are shown.
+    assert_screen("evince_properties_shown", timeout => 30);
 }
 
 sub test_flags {
-        return {always_rollback => 1};
+    return {always_rollback => 1};
 }
 
 1;

--- a/tests/applications/evince/rotate.pm
+++ b/tests/applications/evince/rotate.pm
@@ -7,31 +7,31 @@ use utils;
 
 sub rotate_content {
 
-# Open the application menu
-assert_and_click("gnome_burger_menu", button => "left", timeout => 30);
+    # Open the application menu
+    assert_and_click("gnome_burger_menu", button => "left", timeout => 30);
 
-# Click with the *left* button (needle click area might need some correction)
-assert_and_click("evince_menu_rotate", button => "left", timeout => 30);
+    # Click with the *left* button (needle click area might need some correction)
+    assert_and_click("evince_menu_rotate", button => "left", timeout => 30);
 }
 
 sub run {
-my $self = shift;
+    my $self = shift;
 
-# Rotate the content once.
-rotate_content();
+    # Rotate the content once.
+    rotate_content();
 
-# Check that the window content has been rotated.
-assert_screen("evince_content_rotated_once", timeout => 30);
+    # Check that the window content has been rotated.
+    assert_screen("evince_content_rotated_once", timeout => 30);
 
-# Rotate the content again.
-rotate_content();
+    # Rotate the content again.
+    rotate_content();
 
-# Check that the window content has been rotated.
-assert_screen("evince_content_rotated_twice", timeout => 30);
+    # Check that the window content has been rotated.
+    assert_screen("evince_content_rotated_twice", timeout => 30);
 }
 
 sub test_flags {
-        return {always_rollback => 1};
+    return {always_rollback => 1};
 }
 
 1;

--- a/tests/applications/evince/save_as.pm
+++ b/tests/applications/evince/save_as.pm
@@ -6,31 +6,31 @@ use utils;
 # This part of the suite tests tests that Evince can Save the document As another document.
 
 sub run {
-my $self = shift;
+    my $self = shift;
 
-# Open the menu.
-assert_and_click("gnome_burger_menu", button => "left", timeout => 30);
+    # Open the menu.
+    assert_and_click("gnome_burger_menu", button => "left", timeout => 30);
 
-# Select Save As
-assert_and_click("evince_menu_saveas", button => "left", timeout => 30);
+    # Select Save As
+    assert_and_click("evince_menu_saveas", button => "left", timeout => 30);
 
-# Type a new name.
-type_very_safely("alternative");
+    # Type a new name.
+    type_very_safely("alternative");
 
-# Click on the Save button
-assert_and_click("gnome_button_save_blue", button => "left", timeout => 30);
+    # Click on the Save button
+    assert_and_click("gnome_button_save_blue", button => "left", timeout => 30);
 
-# Now the document is saved under a different name. We will switch to the
-# terminal console to check that it has been created.
-$self->root_console(tty=>3);
-assert_script_run("ls /home/test/Documents/alternative.pdf");
+    # Now the document is saved under a different name. We will switch to the
+    # terminal console to check that it has been created.
+    $self->root_console(tty => 3);
+    assert_script_run("ls /home/test/Documents/alternative.pdf");
 
-# Now, check that the new file does not differ from the original one.
-assert_script_run("diff /home/test/Documents/evince.pdf /home/test/Documents/alternative.pdf");
+    # Now, check that the new file does not differ from the original one.
+    assert_script_run("diff /home/test/Documents/evince.pdf /home/test/Documents/alternative.pdf");
 }
 
 sub test_flags {
-        return {always_rollback => 1};
+    return {always_rollback => 1};
 }
 
 1;

--- a/tests/applications/evince/search.pm
+++ b/tests/applications/evince/search.pm
@@ -6,23 +6,23 @@ use utils;
 # This part of the suite tests the ability to search string in the text.
 
 sub run {
-my $self = shift;
+    my $self = shift;
 
-# Click on the Search button to search for text
-assert_and_click("evince_search_button", button => "left", timeout => 30);
+    # Click on the Search button to search for text
+    assert_and_click("evince_search_button", button => "left", timeout => 30);
 
-# Type *pages*.
-type_very_safely("pages");
-# Press Enter.
-send_key("ret");
+    # Type *pages*.
+    type_very_safely("pages");
+    # Press Enter.
+    send_key("ret");
 
-# Check that the typed text has been found.
-assert_screen("evince_search_found", timeout => 30);
+    # Check that the typed text has been found.
+    assert_screen("evince_search_found", timeout => 30);
 
 }
 
 sub test_flags {
-        return {always_rollback => 1};
+    return {always_rollback => 1};
 }
 
 1;

--- a/tests/applications/evince/shortcuts.pm
+++ b/tests/applications/evince/shortcuts.pm
@@ -6,34 +6,34 @@ use utils;
 # This part of the suite tests that Evince displays shortcuts.
 
 sub run {
-my $self = shift;
+    my $self = shift;
 
-# Open the menu
-assert_and_click("gnome_burger_menu", button => "left", timeout => 30);
-wait_still_screen 2;
+    # Open the menu
+    assert_and_click("gnome_burger_menu", button => "left", timeout => 30);
+    wait_still_screen 2;
 
-# Select the Keyboard Shortcuts item
-assert_and_click("evince_menu_shortcuts", button => "left", timeout => 30);
-wait_still_screen 2;
+    # Select the Keyboard Shortcuts item
+    assert_and_click("evince_menu_shortcuts", button => "left", timeout => 30);
+    wait_still_screen 2;
 
-# Check that Shortcuts has been shown
-assert_screen("evince_shortcuts_shown");
+    # Check that Shortcuts has been shown
+    assert_screen("evince_shortcuts_shown");
 
-# Click on number 2 to arrive to the second page
-assert_and_click("evince_shortcuts_second", button => "left", timeout => 30);
+    # Click on number 2 to arrive to the second page
+    assert_and_click("evince_shortcuts_second", button => "left", timeout => 30);
 
-# Check that Shortcuts 2 has been shown
-assert_screen("evince_shortcuts_second_shown");
+    # Check that Shortcuts 2 has been shown
+    assert_screen("evince_shortcuts_second_shown");
 
-# Click on number 3 to arrive to the second page
-assert_and_click("evince_shortcuts_third", button => "left", timeout => 30);
+    # Click on number 3 to arrive to the second page
+    assert_and_click("evince_shortcuts_third", button => "left", timeout => 30);
 
-# Check that Shortcuts 3 has been shown
-assert_screen("evince_shortcuts_third_shown");
+    # Check that Shortcuts 3 has been shown
+    assert_screen("evince_shortcuts_third_shown");
 }
 
 sub test_flags {
-        return {always_rollback => 1};
+    return {always_rollback => 1};
 }
 
 1;

--- a/tests/apps_gnome_preset.pm
+++ b/tests/apps_gnome_preset.pm
@@ -12,11 +12,11 @@ sub run {
     solidify_wallpaper;
 }
 
-# If this test fails, the others will probably start failing too, 
+# If this test fails, the others will probably start failing too,
 # so there is no need to continue.
 # Also, when subsequent tests fail, the suite will revert to this state for further testing.
 sub test_flags {
-    return { fatal => 1, milestone => 1 };
+    return {fatal => 1, milestone => 1};
 }
 
 1;

--- a/tests/apps_startstop/gnome/abrt.pm
+++ b/tests/apps_startstop/gnome/abrt.pm
@@ -7,7 +7,7 @@ use utils;
 
 sub run {
     my $self = shift;
-    
+
     # Start the application
     start_with_launcher('apps_menu_abrt', 'apps_menu_utilities');
     # Check that it is started

--- a/tests/apps_startstop/gnome/boxes.pm
+++ b/tests/apps_startstop/gnome/boxes.pm
@@ -7,7 +7,7 @@ use utils;
 
 sub run {
     my $self = shift;
-    
+
     # Start the application
     start_with_launcher('apps_menu_boxes');
     # We get tutorial on F32+, directly to main UI on F<32; we can
@@ -23,7 +23,7 @@ sub run {
     register_application("gnome-boxes");
     # Close the application
     quit_with_shortcut();
-    
+
 }
 
 sub test_flags {

--- a/tests/apps_startstop/gnome/calculator.pm
+++ b/tests/apps_startstop/gnome/calculator.pm
@@ -7,7 +7,7 @@ use utils;
 
 sub run {
     my $self = shift;
-    
+
     # Start the application
     start_with_launcher('apps_menu_calculator');
     # Check that it is started

--- a/tests/apps_startstop/gnome/calendar.pm
+++ b/tests/apps_startstop/gnome/calendar.pm
@@ -7,10 +7,10 @@ use utils;
 
 sub run {
     my $self = shift;
-    
+
     # Start the application
     start_with_launcher('apps_menu_calendar');
-    
+
     # give access to location if the vm asks for it
     if (check_screen('apps_run_access', 1)) {
         assert_and_click 'apps_run_access';
@@ -21,7 +21,7 @@ sub run {
     register_application("gnome-calendar");
     # close the application
     quit_with_shortcut();
-    
+
 }
 
 sub test_flags {

--- a/tests/apps_startstop/gnome/chars.pm
+++ b/tests/apps_startstop/gnome/chars.pm
@@ -7,7 +7,7 @@ use utils;
 
 sub run {
     my $self = shift;
-    
+
     # Start the application
     start_with_launcher('apps_menu_chars', 'apps_menu_utilities');
     # Check that is started
@@ -16,7 +16,7 @@ sub run {
     register_application("gnome-characters");
     # Close the application
     quit_with_shortcut();
-    
+
 }
 
 sub test_flags {

--- a/tests/apps_startstop/gnome/cheese.pm
+++ b/tests/apps_startstop/gnome/cheese.pm
@@ -7,7 +7,7 @@ use utils;
 
 sub run {
     my $self = shift;
-    
+
     # Start the application
     start_with_launcher('apps_menu_cheese');
     # Check that is started

--- a/tests/apps_startstop/gnome/clocks.pm
+++ b/tests/apps_startstop/gnome/clocks.pm
@@ -18,7 +18,7 @@ sub run {
     register_application("gnome-clocks");
     # close the application
     quit_with_shortcut();
-    
+
 }
 
 sub test_flags {

--- a/tests/apps_startstop/gnome/diskusage.pm
+++ b/tests/apps_startstop/gnome/diskusage.pm
@@ -7,7 +7,7 @@ use utils;
 
 sub run {
     my $self = shift;
-    
+
     # Start the application
     start_with_launcher('apps_menu_diskusage', 'apps_menu_utilities');
     # Check that is started

--- a/tests/apps_startstop/gnome/files.pm
+++ b/tests/apps_startstop/gnome/files.pm
@@ -3,7 +3,7 @@ use strict;
 use testapi;
 use utils;
 
-# This tests if Files starts 
+# This tests if Files starts
 
 sub run {
     my $self = shift;
@@ -15,7 +15,7 @@ sub run {
     register_application("nautilus");
     # Close the application
     quit_with_shortcut();
-    
+
 }
 
 sub test_flags {

--- a/tests/apps_startstop/gnome/fonts.pm
+++ b/tests/apps_startstop/gnome/fonts.pm
@@ -7,7 +7,7 @@ use utils;
 
 sub run {
     my $self = shift;
-    
+
     # Start the application
     start_with_launcher('apps_menu_fonts', 'apps_menu_utilities');
     # Check that is started

--- a/tests/apps_startstop/gnome/imageviewer.pm
+++ b/tests/apps_startstop/gnome/imageviewer.pm
@@ -7,7 +7,7 @@ use utils;
 
 sub run {
     my $self = shift;
-    
+
     # Start the application
     start_with_launcher('apps_menu_imageviewer', 'apps_menu_utilities');
     # Check that is started

--- a/tests/apps_startstop/gnome/lcalc.pm
+++ b/tests/apps_startstop/gnome/lcalc.pm
@@ -7,7 +7,7 @@ use utils;
 
 sub run {
     my $self = shift;
-    
+
     # Start the application
     start_with_launcher('apps_menu_lcalc');
     # Dismiss 'tip of the day' if necessary

--- a/tests/apps_startstop/gnome/logs.pm
+++ b/tests/apps_startstop/gnome/logs.pm
@@ -7,7 +7,7 @@ use utils;
 
 sub run {
     my $self = shift;
-    
+
     # Start the application
     start_with_launcher('apps_menu_logs', 'apps_menu_utilities');
     # Check that is started

--- a/tests/apps_startstop/gnome/maps.pm
+++ b/tests/apps_startstop/gnome/maps.pm
@@ -7,7 +7,7 @@ use utils;
 
 sub run {
     my $self = shift;
-    
+
     # Start the application
     start_with_launcher('apps_menu_maps');
     # Check that is started
@@ -20,7 +20,7 @@ sub run {
     register_application("gnome-maps");
     # Close the application
     quit_with_shortcut();
-    
+
 }
 
 sub test_flags {

--- a/tests/apps_startstop/gnome/monitor.pm
+++ b/tests/apps_startstop/gnome/monitor.pm
@@ -7,7 +7,7 @@ use utils;
 
 sub run {
     my $self = shift;
-    
+
     # Start the application
     start_with_launcher('apps_menu_monitor');
     # Check that is started

--- a/tests/apps_startstop/gnome/photos.pm
+++ b/tests/apps_startstop/gnome/photos.pm
@@ -7,7 +7,7 @@ use utils;
 
 sub run {
     my $self = shift;
-    
+
     # Start the application
     start_with_launcher('apps_menu_photos');
     # Check that is started

--- a/tests/apps_startstop/gnome/rhythmbox.pm
+++ b/tests/apps_startstop/gnome/rhythmbox.pm
@@ -7,7 +7,7 @@ use utils;
 
 sub run {
     my $self = shift;
-    
+
     # Start the application
     start_with_launcher('apps_menu_rhythmbox');
     # Check that is started

--- a/tests/apps_startstop/gnome/scan.pm
+++ b/tests/apps_startstop/gnome/scan.pm
@@ -7,7 +7,7 @@ use utils;
 
 sub run {
     my $self = shift;
-    
+
     # Start the application
     start_with_launcher('apps_menu_scan');
     # Check that is started
@@ -16,7 +16,7 @@ sub run {
     register_application("simple-scan");
     # Close the application
     quit_with_shortcut();
-    
+
 }
 
 sub test_flags {

--- a/tests/apps_startstop/gnome/screenshot.pm
+++ b/tests/apps_startstop/gnome/screenshot.pm
@@ -7,7 +7,7 @@ use utils;
 
 sub run {
     my $self = shift;
-    
+
     # Start the application
     start_with_launcher('apps_menu_screenshot', 'apps_menu_utilities');
     # Check that is started
@@ -16,7 +16,7 @@ sub run {
     register_application("gnome-screenshot");
     # Close the application
     quit_with_shortcut();
-    
+
 }
 
 sub test_flags {

--- a/tests/apps_startstop/gnome/settings.pm
+++ b/tests/apps_startstop/gnome/settings.pm
@@ -11,11 +11,11 @@ sub run {
     send_key 'alt-f1';
     type_very_safely 'settings';
     send_key 'ret';
-    
+
     # select Background menu item
     assert_and_click 'apps_settings_menu_background';
     wait_still_screen 5;
-    
+
     # close the application
     send_key 'alt-f4';
     wait_still_screen 5;
@@ -24,7 +24,7 @@ sub run {
     assert_screen 'workspace';
     # Register application
     register_application("gnome-control-center");
-    
+
 }
 
 sub test_flags {

--- a/tests/apps_startstop/gnome/software.pm
+++ b/tests/apps_startstop/gnome/software.pm
@@ -7,11 +7,11 @@ use utils;
 
 sub run {
     my $self = shift;
-    
+
     # Start the application
     start_with_launcher('apps_menu_software');
-    
-    
+
+
     # check if a welcome screen appears, if so, click on it
     if (check_screen('apps_run_software_welcome', 1)) {
         assert_and_click 'apps_run_software_welcome';
@@ -22,7 +22,7 @@ sub run {
     register_application("gnome-software");
     # Close the application
     quit_with_shortcut();
-    
+
 }
 
 sub test_flags {

--- a/tests/apps_startstop/gnome/terminal.pm
+++ b/tests/apps_startstop/gnome/terminal.pm
@@ -12,7 +12,7 @@ sub run {
     send_key 'alt-f1';
     wait_still_screen 2;
     type_very_safely 'terminal';
-    send_key 'ret';  
+    send_key 'ret';
     wait_still_screen 5;
     assert_screen "apps_run_terminal";
 
@@ -23,11 +23,11 @@ sub run {
     quit_with_shortcut();
 }
 
-# If this test fails, the others will probably start failing too, 
+# If this test fails, the others will probably start failing too,
 # so there is no need to continue.
 # Also, when subsequent tests fail, the suite will revert to this state for further testing.
 sub test_flags {
-    return { fatal => 1, milestone => 1 };
+    return {fatal => 1, milestone => 1};
 }
 
 1;

--- a/tests/apps_startstop/gnome/texteditor.pm
+++ b/tests/apps_startstop/gnome/texteditor.pm
@@ -7,7 +7,7 @@ use utils;
 
 sub run {
     my $self = shift;
-    
+
     # Start the application
     start_with_launcher('apps_menu_texteditor');
     # Check that is started

--- a/tests/apps_startstop/gnome/videos.pm
+++ b/tests/apps_startstop/gnome/videos.pm
@@ -7,7 +7,7 @@ use utils;
 
 sub run {
     my $self = shift;
-    
+
     # Start the application
     start_with_launcher('apps_menu_videos');
     # Check that is started

--- a/tests/apps_startstop/gnome/weather.pm
+++ b/tests/apps_startstop/gnome/weather.pm
@@ -19,7 +19,7 @@ sub run {
     register_application("gnome-weather");
     # close the application
     quit_with_shortcut();
-    
+
 }
 
 sub test_flags {

--- a/tests/apps_startstop/kde/cteditor.pm
+++ b/tests/apps_startstop/kde/cteditor.pm
@@ -7,7 +7,7 @@ use utils;
 
 sub run {
     my $self = shift;
-    
+
     menu_launch_type 'contactthemeeditor';
     # Check that it is started
     assert_screen 'cteditor_runs';

--- a/tests/apps_startstop/kde/dbusviewer.pm
+++ b/tests/apps_startstop/kde/dbusviewer.pm
@@ -7,7 +7,7 @@ use utils;
 
 sub run {
     my $self = shift;
-   
+
     menu_launch_type 'dbusviewer';
     # Check that it is started
     assert_screen 'dbusviewer_runs';

--- a/tests/apps_startstop/kde/discover.pm
+++ b/tests/apps_startstop/kde/discover.pm
@@ -7,7 +7,7 @@ use utils;
 
 sub run {
     my $self = shift;
-    
+
     # Start the application
     menu_launch_type 'discover';
     # Check that it is started

--- a/tests/apps_startstop/kde/dnfdragora.pm
+++ b/tests/apps_startstop/kde/dnfdragora.pm
@@ -7,7 +7,7 @@ use utils;
 
 sub run {
     my $self = shift;
-    
+
     # Start the application
     menu_launch_type 'dnfdragora';
     # Check that it is started

--- a/tests/apps_startstop/kde/dolphin.pm
+++ b/tests/apps_startstop/kde/dolphin.pm
@@ -7,7 +7,7 @@ use utils;
 
 sub run {
     my $self = shift;
-    
+
     # Start the application
     menu_launch_type 'dolphin';
     # Check that it is started

--- a/tests/apps_startstop/kde/firefox.pm
+++ b/tests/apps_startstop/kde/firefox.pm
@@ -7,7 +7,7 @@ use utils;
 
 sub run {
     my $self = shift;
-    
+
     # Start the application
     menu_launch_type 'firefox';
     # Check that it is started; this needle is from

--- a/tests/apps_startstop/kde/firewall.pm
+++ b/tests/apps_startstop/kde/firewall.pm
@@ -7,14 +7,14 @@ use utils;
 
 sub run {
     my $self = shift;
-    
+
     # Start the application
     menu_launch_type 'firewall';
     sleep 5;
     # Firewall requires password to be entered and confirmed to start.
     # View password
     assert_screen "auth_required";
-    my $password = get_var('ROOT_PASSWORD','weakpassword');
+    my $password = get_var('ROOT_PASSWORD', 'weakpassword');
     type_very_safely $password;
     send_key 'ret';
     sleep 5;

--- a/tests/apps_startstop/kde/gwenview.pm
+++ b/tests/apps_startstop/kde/gwenview.pm
@@ -7,7 +7,7 @@ use utils;
 
 sub run {
     my $self = shift;
-    
+
     # Start the application
     menu_launch_type 'gwenview';
     # Check that it is started

--- a/tests/apps_startstop/kde/help.pm
+++ b/tests/apps_startstop/kde/help.pm
@@ -7,7 +7,7 @@ use utils;
 
 sub run {
     my $self = shift;
-    
+
     # Start the application
     menu_launch_type 'help';
     # Check that it is started

--- a/tests/apps_startstop/kde/infocenter.pm
+++ b/tests/apps_startstop/kde/infocenter.pm
@@ -9,7 +9,7 @@ use utils;
 
 sub run {
     my $self = shift;
-    
+
     # Start the application
     menu_launch_type 'info';
     # Check that it is started

--- a/tests/apps_startstop/kde/kaddressbook.pm
+++ b/tests/apps_startstop/kde/kaddressbook.pm
@@ -7,7 +7,7 @@ use utils;
 
 sub run {
     my $self = shift;
-    
+
     # Start the application
     menu_launch_type 'kaddressbook';
     # Check that it is started

--- a/tests/apps_startstop/kde/kcalc.pm
+++ b/tests/apps_startstop/kde/kcalc.pm
@@ -7,7 +7,7 @@ use utils;
 
 sub run {
     my $self = shift;
-    
+
     # Start the application
     menu_launch_type 'kcalc';
     # Check that it is started

--- a/tests/apps_startstop/kde/kcharselect.pm
+++ b/tests/apps_startstop/kde/kcharselect.pm
@@ -7,7 +7,7 @@ use utils;
 
 sub run {
     my $self = shift;
-    
+
     # Start the application
     menu_launch_type 'kcharselect';
     # Check that it is started

--- a/tests/apps_startstop/kde/kcolorchooser.pm
+++ b/tests/apps_startstop/kde/kcolorchooser.pm
@@ -7,7 +7,7 @@ use utils;
 
 sub run {
     my $self = shift;
-    
+
     # Start the application
     menu_launch_type 'kcolorchooser';
     # Check that it is started

--- a/tests/apps_startstop/kde/kfind.pm
+++ b/tests/apps_startstop/kde/kfind.pm
@@ -7,7 +7,7 @@ use utils;
 
 sub run {
     my $self = shift;
-    
+
     # Start the application
     menu_launch_type 'kfind';
     # Check that it is started

--- a/tests/apps_startstop/kde/kgpg.pm
+++ b/tests/apps_startstop/kde/kgpg.pm
@@ -7,7 +7,7 @@ use utils;
 
 sub run {
     my $self = shift;
-    
+
     # Start the application
     menu_launch_type 'kgpg';
     # Deal with the first wizard screen

--- a/tests/apps_startstop/kde/kimport.pm
+++ b/tests/apps_startstop/kde/kimport.pm
@@ -7,7 +7,7 @@ use utils;
 
 sub run {
     my $self = shift;
-    
+
     # Start the application
     menu_launch_type 'akonadiimportwizard';
     # Click ok to go further

--- a/tests/apps_startstop/kde/kmag.pm
+++ b/tests/apps_startstop/kde/kmag.pm
@@ -7,7 +7,7 @@ use utils;
 
 sub run {
     my $self = shift;
-    
+
     # Start the application
     menu_launch_type 'kmag';
     # Check that it is started

--- a/tests/apps_startstop/kde/kmail.pm
+++ b/tests/apps_startstop/kde/kmail.pm
@@ -7,7 +7,7 @@ use utils;
 
 sub run {
     my $self = shift;
-    
+
     # Start the application
     menu_launch_type 'kmail';
     # Enable unified mailboxes, if they appear

--- a/tests/apps_startstop/kde/kmail_header.pm
+++ b/tests/apps_startstop/kde/kmail_header.pm
@@ -7,7 +7,7 @@ use utils;
 
 sub run {
     my $self = shift;
-    
+
     # Start the application
     menu_launch_type 'kmail header';
     # Check that the application runs

--- a/tests/apps_startstop/kde/kmousetool.pm
+++ b/tests/apps_startstop/kde/kmousetool.pm
@@ -7,7 +7,7 @@ use utils;
 
 sub run {
     my $self = shift;
-    
+
     # Start the application
     menu_launch_type 'kmousetool';
     # Check that it is started

--- a/tests/apps_startstop/kde/kmouth.pm
+++ b/tests/apps_startstop/kde/kmouth.pm
@@ -7,14 +7,14 @@ use utils;
 
 sub run {
     my $self = shift;
-    
+
     # Start the application
     menu_launch_type 'kmouth';
     sleep 2;
     # Deal with the welcome screens
     assert_screen ["kde_next", "kde_finish"];
     while (match_has_tag "kde_next") {
-        assert_and_click "kde_next"; 
+        assert_and_click "kde_next";
         sleep 2;
         assert_screen ["kde_next", "kde_finish"];
     }

--- a/tests/apps_startstop/kde/kolourpaint.pm
+++ b/tests/apps_startstop/kde/kolourpaint.pm
@@ -7,7 +7,7 @@ use utils;
 
 sub run {
     my $self = shift;
-    
+
     # Start the application
     menu_launch_type 'kolourpaint';
     # Check that it is started

--- a/tests/apps_startstop/kde/konsole.pm
+++ b/tests/apps_startstop/kde/konsole.pm
@@ -7,7 +7,7 @@ use utils;
 
 sub run {
     my $self = shift;
-    
+
     # Start the application
     menu_launch_type 'konsole';
     # Check that it is started

--- a/tests/apps_startstop/kde/kontakt.pm
+++ b/tests/apps_startstop/kde/kontakt.pm
@@ -7,7 +7,7 @@ use utils;
 
 sub run {
     my $self = shift;
-    
+
     # Start the application
     menu_launch_type 'kontact';
     # Enable unified mailboxes, if they appear

--- a/tests/apps_startstop/kde/konversation.pm
+++ b/tests/apps_startstop/kde/konversation.pm
@@ -7,7 +7,7 @@ use utils;
 
 sub run {
     my $self = shift;
-    
+
     # Start the application
     menu_launch_type 'konversation';
     # Connect to Freenode

--- a/tests/apps_startstop/kde/korganizer.pm
+++ b/tests/apps_startstop/kde/korganizer.pm
@@ -7,7 +7,7 @@ use utils;
 
 sub run {
     my $self = shift;
-    
+
     # Start the application
     menu_launch_type 'korganizer';
     # Check that it is started

--- a/tests/apps_startstop/kde/kparted.pm
+++ b/tests/apps_startstop/kde/kparted.pm
@@ -7,7 +7,7 @@ use utils;
 
 sub run {
     my $self = shift;
-    
+
     # Start the application
     menu_launch_type 'partition editor';
     wait_still_screen 2;

--- a/tests/apps_startstop/kde/krdc.pm
+++ b/tests/apps_startstop/kde/krdc.pm
@@ -7,7 +7,7 @@ use utils;
 
 sub run {
     my $self = shift;
-    
+
     # Start the application
     menu_launch_type 'krdc';
     # Check that it is started

--- a/tests/apps_startstop/kde/krfb.pm
+++ b/tests/apps_startstop/kde/krfb.pm
@@ -7,7 +7,7 @@ use utils;
 
 sub run {
     my $self = shift;
-    
+
     # Start the application
     menu_launch_type 'krfb';
     # Check that it is started

--- a/tests/apps_startstop/kde/kruler.pm
+++ b/tests/apps_startstop/kde/kruler.pm
@@ -7,7 +7,7 @@ use utils;
 
 sub run {
     my $self = shift;
-    
+
     # Start the application
     menu_launch_type 'kruler';
     # Check that it is started

--- a/tests/apps_startstop/kde/ktnef.pm
+++ b/tests/apps_startstop/kde/ktnef.pm
@@ -7,7 +7,7 @@ use utils;
 
 sub run {
     my $self = shift;
-    
+
     # Start the application
     menu_launch_type 'ktnef';
     # Check that it is started

--- a/tests/apps_startstop/kde/kwallet.pm
+++ b/tests/apps_startstop/kde/kwallet.pm
@@ -7,7 +7,7 @@ use utils;
 
 sub run {
     my $self = shift;
-    
+
     # Start the application
     menu_launch_type 'kwallet';
     # Check that it is started

--- a/tests/apps_startstop/kde/kwrite.pm
+++ b/tests/apps_startstop/kde/kwrite.pm
@@ -7,7 +7,7 @@ use utils;
 
 sub run {
     my $self = shift;
-    
+
     # Start the application
     menu_launch_type 'kwrite';
     # Check that it is started

--- a/tests/apps_startstop/kde/language.pm
+++ b/tests/apps_startstop/kde/language.pm
@@ -7,7 +7,7 @@ use utils;
 
 sub run {
     my $self = shift;
-    
+
     # Start the application
     menu_launch_type 'language';
     # Deal with confirmation window

--- a/tests/apps_startstop/kde/mahjong.pm
+++ b/tests/apps_startstop/kde/mahjong.pm
@@ -7,7 +7,7 @@ use utils;
 
 sub run {
     my $self = shift;
-    
+
     # Start the application
     menu_launch_type 'kmahjong';
     # Check that it is started

--- a/tests/apps_startstop/kde/mediawriter.pm
+++ b/tests/apps_startstop/kde/mediawriter.pm
@@ -7,7 +7,7 @@ use utils;
 
 sub run {
     my $self = shift;
-    
+
     # Start the application
     menu_launch_type 'mediawriter';
     # Check that it is started

--- a/tests/apps_startstop/kde/minesweeper.pm
+++ b/tests/apps_startstop/kde/minesweeper.pm
@@ -7,7 +7,7 @@ use utils;
 
 sub run {
     my $self = shift;
-    
+
     # Start the application
     menu_launch_type 'kmines';
     # Check that it is started

--- a/tests/apps_startstop/kde/netcon.pm
+++ b/tests/apps_startstop/kde/netcon.pm
@@ -7,7 +7,7 @@ use utils;
 
 sub run {
     my $self = shift;
-    
+
     # Start the application
     menu_launch_type 'network configuration';
     # Check that it is started

--- a/tests/apps_startstop/kde/patience.pm
+++ b/tests/apps_startstop/kde/patience.pm
@@ -7,7 +7,7 @@ use utils;
 
 sub run {
     my $self = shift;
-    
+
     # Start the application
     menu_launch_type 'kpatience';
     # Check that it is started

--- a/tests/apps_startstop/kde/pimexporter.pm
+++ b/tests/apps_startstop/kde/pimexporter.pm
@@ -7,7 +7,7 @@ use utils;
 
 sub run {
     my $self = shift;
-    
+
     # Start the application
     menu_launch_type 'pim';
     # Check that it is started

--- a/tests/apps_startstop/kde/spectacle.pm
+++ b/tests/apps_startstop/kde/spectacle.pm
@@ -7,7 +7,7 @@ use utils;
 
 sub run {
     my $self = shift;
-    
+
     # Start the application
     menu_launch_type 'spectacle';
     # Check that it is started

--- a/tests/apps_startstop/kde/system_settings.pm
+++ b/tests/apps_startstop/kde/system_settings.pm
@@ -7,7 +7,7 @@ use utils;
 
 sub run {
     my $self = shift;
-    
+
     # Start the application
     menu_launch_type 'system settings';
     # Check that it is started

--- a/tests/apps_startstop/kde/vault.pm
+++ b/tests/apps_startstop/kde/vault.pm
@@ -30,7 +30,7 @@ sub run {
 
     # Enter the name of the newly created testvault
     assert_and_click "vault_enter_name";
-    
+
     # Then name the vault "testvault"
     type_very_safely "testvault";
 

--- a/tests/autocloud.pm
+++ b/tests/autocloud.pm
@@ -23,7 +23,7 @@ sub run {
     assert_script_run "chmod ugo+w /dev/" . $serialdev;
     # let's go to another tty and login as regular user
     send_key "alt-f2";
-    console_login(user=>"test", password=>"weakpassword");
+    console_login(user => "test", password => "weakpassword");
     assert_script_run "curl -O https://fedorapeople.org/groups/qa/tunirtests.tar.gz";
     assert_script_run "tar xvf tunirtests.tar.gz";
     assert_script_run "sudo python3 -m unittest tunirtests.atomictests.TestAtomic01Status -v";
@@ -45,24 +45,24 @@ sub run {
     assert_script_run "sudo python3 -m unittest tunirtests.cloudservice.TestServiceDisable -v";
     type_string "sudo reboot\n";
     boot_to_login_screen(timeout => 180);
-    console_login(user=>"root", password=>"weakpassword");
+    console_login(user => "root", password => "weakpassword");
     # we need to use script_run as regular user again
     assert_script_run "sudo chmod ugo+w /dev/" . $serialdev;
     # let's go to another tty and login as regular user again
     send_key "alt-f2";
-    console_login(user=>"test", password=>"weakpassword");
+    console_login(user => "test", password => "weakpassword");
     _soft_fail_run "tunirtests.testreboot.TestReboot";
     assert_script_run "sudo python3 -m unittest tunirtests.cloudservice.TestServiceManipulation -v";
     # this test only works properly as a regular user
     _soft_fail_run "tunirtests.cloudtests.TestJournalWrittenAfterReboot", 0;
     type_string "sudo reboot\n";
     boot_to_login_screen(timeout => 180);
-    console_login(user=>"root", password=>"weakpassword");
+    console_login(user => "root", password => "weakpassword");
     # we need to use script_run as regular user again
     assert_script_run "sudo chmod ugo+w /dev/" . $serialdev;
     # let's go to another tty and login as regular user again
     send_key "alt-f2";
-    console_login(user=>"test", password=>"weakpassword");
+    console_login(user => "test", password => "weakpassword");
     assert_script_run "sudo python3 -m unittest tunirtests.cloudservice.TestServiceAfter -v";
     assert_script_run "sudo python3 -m unittest tunirtests.atomictests.TestDockerInstalled -v";
     assert_script_run "sudo python3 -m unittest tunirtests.atomictests.TestDockerStorageSetup -v";
@@ -76,7 +76,7 @@ sub run {
 
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/base_package_install_remove.pm
+++ b/tests/base_package_install_remove.pm
@@ -6,7 +6,7 @@ use utils;
 sub run {
     my $self = shift;
     # switch to TTY3 for both, graphical and console tests
-    $self->root_console(tty=>3);
+    $self->root_console(tty => 3);
 
     # This test case tests that packages can be correctly installed and removed.
     # We will test by installing two packages - ftp and mc.
@@ -49,7 +49,7 @@ sub run {
 
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/base_reboot_unmount.pm
+++ b/tests/base_reboot_unmount.pm
@@ -19,21 +19,21 @@ sub test_routine {
 sub run {
     my $self = shift;
     # switch to TTY3 for both graphical and console tests
-    $self->root_console(tty=>3);
+    $self->root_console(tty => 3);
     # Run test for the first time
     test_routine();
     # Reboot the system.
     type_safely "reboot\n";
     # This time, we will need to login manually.
     boot_to_login_screen;
-    $self->root_console(tty=>3);
+    $self->root_console(tty => 3);
 
     # Run the tests for the second time.
     test_routine();
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/base_selinux.pm
+++ b/tests/base_selinux.pm
@@ -4,15 +4,15 @@ use testapi;
 use utils;
 
 sub run {
-    my $self=shift;
+    my $self = shift;
     # switch to TTY3 for both, graphical and console tests
-    $self->root_console(tty=>3);
+    $self->root_console(tty => 3);
     validate_script_output 'getenforce', sub { $_ =~ m/Enforcing/ };
 }
 
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/base_service_manipulation.pm
+++ b/tests/base_service_manipulation.pm
@@ -6,7 +6,7 @@ use utils;
 sub run {
     my $self = shift;
     # switch to TTY3 for both, graphical and console tests
-    $self->root_console(tty=>3);
+    $self->root_console(tty => 3);
     # we could make this slightly more 'efficient' by assuming chronyd
     # is always going to be enabled/running at first, but it's safer
     # to force an expected starting state.
@@ -14,7 +14,7 @@ sub run {
     script_run "systemctl disable chronyd.service";
     script_run "reboot", 0;
     boot_to_login_screen;
-    $self->root_console(tty=>3);
+    $self->root_console(tty => 3);
     # note the use of ! here is a bash-ism, but it sure makes life easier
     assert_script_run '! systemctl is-enabled chronyd.service';
     assert_script_run '! systemctl is-active chronyd.service';
@@ -33,14 +33,14 @@ sub run {
     assert_script_run '! ps -C chronyd';
     script_run "reboot", 0;
     boot_to_login_screen;
-    $self->root_console(tty=>3);
+    $self->root_console(tty => 3);
     assert_script_run 'systemctl is-enabled chronyd.service';
     assert_script_run 'systemctl is-active chronyd.service';
     assert_script_run 'ps -C chronyd';
     script_run "systemctl disable chronyd.service";
     script_run "reboot", 0;
     boot_to_login_screen;
-    $self->root_console(tty=>3);
+    $self->root_console(tty => 3);
     assert_script_run '! systemctl is-enabled chronyd.service';
     assert_script_run '! systemctl is-active chronyd.service';
     assert_script_run '! ps -C chronyd';
@@ -48,7 +48,7 @@ sub run {
 
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/base_services_start.pm
+++ b/tests/base_services_start.pm
@@ -5,7 +5,7 @@ use testapi;
 sub run {
     my $self = shift;
     # switch to TTY3 for both, graphical and console tests
-    $self->root_console(tty=>3);
+    $self->root_console(tty => 3);
     # "Job foo.service/start deleted to break ordering cycle"-type
     # message in the log indicates a service got taken out of the boot
     # process to resolve some kind of dependency loop, see e.g.
@@ -42,7 +42,7 @@ sub run {
 
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/base_system_logging.pm
+++ b/tests/base_system_logging.pm
@@ -3,9 +3,9 @@ use strict;
 use testapi;
 
 sub run {
-    my $self=shift;
+    my $self = shift;
     # switch to TTY3 for both, graphical and console tests
-    $self->root_console(tty=>3);
+    $self->root_console(tty => 3);
     # Check that journalctl DOESN'T output "No entries". This is also the case when journal files are missing.
     # NOTE: We are quietly assuming that something was logged in journal in last 30 minutes. Should be boot log,
     # switch to TTY3 etc.
@@ -16,7 +16,7 @@ sub run {
 
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/base_update_cli.pm
+++ b/tests/base_update_cli.pm
@@ -6,7 +6,7 @@ use packagetest;
 sub run {
     my $self = shift;
     # switch to TTY3 for both, graphical and console tests
-    $self->root_console(tty=>3);
+    $self->root_console(tty => 3);
     # enable test repos and install test packages
     prepare_test_packages;
     # check rpm agrees they installed good
@@ -24,7 +24,7 @@ sub run {
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/btrfs_preserve_home_check_content.pm
+++ b/tests/btrfs_preserve_home_check_content.pm
@@ -4,18 +4,18 @@ use testapi;
 use utils;
 
 sub run {
-    my $self=shift;
+    my $self = shift;
     # switch to TTY3 for both, graphical and console tests
-    $self->root_console(tty=>3);
+    $self->root_console(tty => 3);
     # The pre-created image has a special file left in the home
-    # directory. This checks that the file has been left there 
+    # directory. This checks that the file has been left there
     # correctly after system reinstall.
     assert_script_run "ls /home/home_preserved";
 }
 
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/database_client.pm
+++ b/tests/database_client.pm
@@ -6,7 +6,7 @@ use tapnet;
 use utils;
 
 sub run {
-    my $self=shift;
+    my $self = shift;
     # use compose repo, disable u-t, etc.
     repo_setup();
     # install postgresql
@@ -19,7 +19,7 @@ sub run {
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/desktop_background.pm
+++ b/tests/desktop_background.pm
@@ -14,7 +14,7 @@ sub run {
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/desktop_browser.pm
+++ b/tests/desktop_browser.pm
@@ -30,54 +30,54 @@ sub run {
     check_desktop;
     send_key 'alt-f1';
     # wait out animations
-    wait_still_screen(stilltime=>4, similarity_level=>45);
+    wait_still_screen(stilltime => 4, similarity_level => 45);
     assert_and_click 'browser_launcher';
     assert_screen 'browser', 45;
     # firefox is quite grindy on startup, let it settle
-    wait_still_screen(stilltime=>5, similarity_level=>45);
+    wait_still_screen(stilltime => 5, similarity_level => 45);
     # open a new tab so we don't race with the default page load
     # (also focuses the location bar for us)
     _open_new_tab;
-    wait_still_screen(stilltime=>5, similarity_level=>45);
+    wait_still_screen(stilltime => 5, similarity_level => 45);
     sleep 3;
     # check FAS, typing slowly to avoid errors
     type_very_safely "https://admin.fedoraproject.org/accounts/\n";
     assert_screen "browser_fas_home";
     _open_new_tab;
-    wait_still_screen(stilltime=>2, similarity_level=>45);
+    wait_still_screen(stilltime => 2, similarity_level => 45);
     sleep 2;
     type_very_safely "https://kernel.org\n";
     assert_and_click "browser_kernelorg_patch";
-    wait_still_screen(stilltime=>2, similarity_level=>45);
+    wait_still_screen(stilltime => 2, similarity_level => 45);
     assert_and_click "browser_download_save";
     sleep 2;
     send_key 'ret';
-    wait_still_screen(stilltime=>3, similarity_level=>45);
+    wait_still_screen(stilltime => 3, similarity_level => 45);
     # browsers do...something...when the download completes, and we
     # expect there's a single click to make it go away and return
     # browser to a state where we can open a new tab
     assert_and_click "browser_download_complete";
-    wait_still_screen(stilltime=>2, similarity_level=>45);
+    wait_still_screen(stilltime => 2, similarity_level => 45);
     # we'll check it actually downloaded later
     # add-on test: at present all desktops we test (KDE, GNOME) are
     # using Firefox by default so we do this unconditionally, but we
     # may need to conditionalize it if we ever test desktops whose
     # default browser doesn't support add-ons or uses different ones
     _open_new_tab;
-    wait_still_screen(stilltime=>2, similarity_level=>45);
+    wait_still_screen(stilltime => 2, similarity_level => 45);
     sleep 2;
     type_very_safely "https://addons.mozilla.org/en-US/firefox/addon/ublock-origin/\n";
     assert_and_click "firefox_addon_add";
     assert_and_click "firefox_addon_install";
     assert_and_click "firefox_addon_success";
     # go to a console and check download worked
-    $self->root_console(tty=>3);
+    $self->root_console(tty => 3);
     my $user = get_var("USER_LOGIN", "test");
     assert_script_run "test -e /home/$user/Downloads/patch-*.xz";
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/desktop_login.pm
+++ b/tests/desktop_login.pm
@@ -88,7 +88,7 @@ sub login_user {
         type_very_safely "$password\n";
     }
     type_very_safely "$password\n";
-    check_desktop(timeout=>60) if ($args{checklogin});
+    check_desktop(timeout => 60) if ($args{checklogin});
     wait_still_screen 5;
 }
 
@@ -169,7 +169,7 @@ sub reboot_system {
                 # And for KDE and GNOME >= F33:
                 assert_and_click "reboot_entry";
             }
-        assert_and_click "restart_confirm";
+            assert_and_click "restart_confirm";
         }
     }
     # When we are outside KDE (not logged in), the only way to reboot is to click
@@ -199,7 +199,7 @@ sub run {
     our $desktop = get_var("DESKTOP");
     # replace the wallpaper with a black image, this should work for
     # all desktops. Takes effect after a logout / login cycle
-    $self->root_console(tty=>3);
+    $self->root_console(tty => 3);
     assert_script_run "dnf -y install GraphicsMagick", 300;
     assert_script_run "gm convert -size 1024x768 xc:black /usr/share/backgrounds/black.png";
     assert_script_run 'for i in /usr/share/backgrounds/f*/default/*.png; do ln -sf /usr/share/backgrounds/black.png $i; done';
@@ -207,7 +207,7 @@ sub run {
         # use solid blue background for SDDM
         assert_script_run "sed -i -e 's,image,solid,g' /usr/share/sddm/themes/01-breeze-fedora/theme.conf.user";
     }
-    adduser(name=>"Jack Sparrow", login=>"jack", password=>$jackpass);
+    adduser(name => "Jack Sparrow", login => "jack", password => $jackpass);
     if ($desktop eq "gnome") {
         # suppress the Welcome Tour for new users in GNOME 40+
         assert_script_run 'printf "[org.gnome.shell]\nwelcome-dialog-last-shown-version=\'4294967295\'\n" > /usr/share/glib-2.0/schemas/org.gnome.shell.gschema.override';
@@ -215,12 +215,12 @@ sub run {
         # In Gnome, we can create a passwordless user that can provide his password upon
         # the first login. So we can create the second user in this way to test this feature
         # later.
-        adduser(name=>"Jim Eagle", login=>"jim", password=>"askuser");
+        adduser(name => "Jim Eagle", login => "jim", password => "askuser");
     }
     else {
         # In KDE, we can also create a passwordless user, but we cannot log into the system
         # later, so we will create the second user the standard way.
-        adduser(name=>"Jim Eagle", login=>"jim", password=>$jimpass);
+        adduser(name => "Jim Eagle", login => "jim", password => $jimpass);
     }
 
     # Clean boot the system, and note what accounts are listed on the login screen.
@@ -230,7 +230,7 @@ sub run {
     boot_to_login_screen;
 
     # Log in with the first user account.
-    login_user(user=>"jack", password=>$jackpass);
+    login_user(user => "jack", password => $jackpass);
     check_user_logged_in("jack");
     # Log out the user.
     logout_user();
@@ -238,18 +238,18 @@ sub run {
     # Log in with the second user account. The second account, Jim Eagle,
     if ($desktop eq "gnome") {
         # If we are in Gnome, we will this time assign a password on first log-in.
-        login_user(user=>"jim", password=>$jimpass, method=>"create");
+        login_user(user => "jim", password => $jimpass, method => "create");
     }
     else {
         # If not, we are in KDE and we will log in normally.
-        login_user(user=>"jim", password=>$jimpass);
+        login_user(user => "jim", password => $jimpass);
     }
     check_user_logged_in("jim");
     # And this time reboot the system using the menu.
     reboot_system();
 
     # Try to log in with either account, intentionally entering the wrong password.
-    login_user(user=>"jack", password=>"wrongpassword", checklogin=>0);
+    login_user(user => "jack", password => "wrongpassword", checklogin => 0);
     my $relnum = get_release_number;
     if ($desktop eq "gnome" && $relnum < 34) {
         # In GDM before F34, a message is shown about an unsuccessful login
@@ -265,13 +265,13 @@ sub run {
     # Now, log into the system again using the correct password. This will
     # only work if we were correctly denied login with the wrong password,
     # if we were let in with the wrong password it'll fail
-    login_user(user=>"jim", password=>$jimpass);
+    login_user(user => "jim", password => $jimpass);
     check_user_logged_in("jim");
 
     # Lock the screen and unlock again.
     lock_screen();
     # Use the password to unlock the screen.
-    login_user(user=>"jim", password=>$jimpass, method=>"unlock");
+    login_user(user => "jim", password => $jimpass, method => "unlock");
 
     # Switch user tests
     if ($desktop eq "gnome") {
@@ -286,7 +286,7 @@ sub run {
         # Initiate switch user
         switch_user();
         # Now, we get a new login screen, so let's do the login into the new session.
-        login_user(user=>"jack", password=>$jackpass);
+        login_user(user => "jack", password => $jackpass);
         # Check that it is a new session, the terminal window should not be visible.
         if (check_screen "user_confirm_jim") {
             die "The session was not switched!";
@@ -298,7 +298,7 @@ sub run {
         logout_user();
         # Now, let us log into the original session, this time, the terminal window
         # should still be visible.
-        login_user(user=>"jim", password=>$jimpass);
+        login_user(user => "jim", password => $jimpass);
         assert_screen "user_confirm_jim";
 
         # We will also test another alternative - switching the user from
@@ -306,7 +306,7 @@ sub run {
         lock_screen();
         send_key "ret";
         switch_user();
-        login_user(user=>"jack", password=>$jackpass);
+        login_user(user => "jack", password => $jackpass);
         check_user_logged_in("jack");
     }
     # Power off the machine
@@ -314,7 +314,7 @@ sub run {
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/desktop_notifications.pm
+++ b/tests/desktop_notifications.pm
@@ -17,14 +17,14 @@ sub run {
     my $version_major = get_version_major;
     # for the live image case, handle bootloader here
     if (get_var("BOOTFROM")) {
-        do_bootloader(postinstall=>1, params=>'3');
+        do_bootloader(postinstall => 1, params => '3');
     }
     else {
-        do_bootloader(postinstall=>0, params=>'3');
+        do_bootloader(postinstall => 0, params => '3');
     }
     boot_to_login_screen;
     # use tty1 to avoid RHBZ #1821499 on F32 Workstation live
-    $self->root_console(tty=>1);
+    $self->root_console(tty => 1);
     # ensure we actually have some package updates available
     prepare_test_packages;
     if ($desktop eq 'gnome') {
@@ -43,11 +43,11 @@ sub run {
             # get notifications, see:
             # https://wiki.gnome.org/Design/Apps/Software/Updates#Tentative_Design
             my $now = script_output 'date +%s';
-            my $yyday = $now - 2*24*60*60;
-            my $longago = $now - 14*24*60*60;
+            my $yyday = $now - 2 * 24 * 60 * 60;
+            my $longago = $now - 14 * 24 * 60 * 60;
             # have to log in as the user to do this
             script_run 'exit', 0;
-            console_login(user=>get_var('USER_LOGIN', 'test'), password=>get_var('USER_PASSWORD', 'weakpassword'));
+            console_login(user => get_var('USER_LOGIN', 'test'), password => get_var('USER_PASSWORD', 'weakpassword'));
             script_run "gsettings set org.gnome.software check-timestamp ${yyday}", 0;
             script_run "gsettings set org.gnome.software update-notification-timestamp ${longago}", 0;
             script_run "gsettings set org.gnome.software online-updates-timestamp ${longago}", 0;
@@ -55,7 +55,7 @@ sub run {
             script_run "gsettings set org.gnome.software install-timestamp ${longago}", 0;
             wait_still_screen 5;
             script_run 'exit', 0;
-            console_login(user=>'root', password=>get_var('ROOT_PASSWORD', 'weakpassword'));
+            console_login(user => 'root', password => get_var('ROOT_PASSWORD', 'weakpassword'));
         }
     }
     # can't use assert_script_run here as long as we're on tty1
@@ -76,14 +76,14 @@ sub run {
         type_very_safely get_var("USER_PASSWORD", "weakpassword");
         send_key 'ret';
     }
-    check_desktop(timeout=>90);
+    check_desktop(timeout => 90);
     # now, WE WAIT. Because KDE on F34+ shows a notification only
     # briefly we will keep an eye out and record if we saw it (logic
     # around this comes later). But we wait the whole ten minutes even
     # if we see it  so we catch any unwanted notifications that appear
     # shortly after boot
     my $seen = 0;
-    for my $n (1..16) {
+    for my $n (1 .. 16) {
         $seen = 1 if (check_screen "desktop_update_notification", 30);
         mouse_set 20, 20;
         send_key "spc";
@@ -148,7 +148,7 @@ sub run {
 
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/desktop_printing.pm
+++ b/tests/desktop_printing.pm
@@ -8,11 +8,11 @@ sub run {
     # Prepare the environment:
     #
     # Become root
-    $self->root_console(tty=>3);
+    $self->root_console(tty => 3);
 
     # Create a text file with content to print
-    script_run  "cd /home/test/";
-    assert_script_run  "echo 'A quick brown fox jumps over a lazy dog.' > testfile.txt";
+    script_run "cd /home/test/";
+    assert_script_run "echo 'A quick brown fox jumps over a lazy dog.' > testfile.txt";
     script_run "chmod 666 testfile.txt";
     # Install the Cups-PDF package to use the Cups-PDF printer
     assert_script_run "dnf -y install cups-pdf", 180;
@@ -37,12 +37,12 @@ sub run {
 
     # Open the text editor and print the file.
     wait_screen_change { send_key "alt-f2"; };
-    wait_still_screen(stilltime=>5, similarity_level=>45);
+    wait_still_screen(stilltime => 5, similarity_level => 45);
     type_very_safely "$editor /home/test/testfile.txt\n";
-    wait_still_screen(stilltime=>5, similarity_level=>44);
+    wait_still_screen(stilltime => 5, similarity_level => 44);
     # Print the file using the Cups-PDF printer
     send_key "ctrl-p";
-    wait_still_screen(stilltime=>5, similarity_level=>45);
+    wait_still_screen(stilltime => 5, similarity_level => 45);
     if ($desktop eq 'gnome') {
         assert_and_click "printing_select_pdfprinter";
     }
@@ -52,7 +52,7 @@ sub run {
         # We only check that it is correct.
         assert_screen "printing_pdfprinter_ready";
     }
-    wait_still_screen(stilltime=>2, similarity_level=>45);
+    wait_still_screen(stilltime => 2, similarity_level => 45);
     assert_and_click "printing_print";
     # Exit the application
     send_key "alt-f4";
@@ -63,7 +63,7 @@ sub run {
 
     # Open the pdf file and check the print
     send_key "alt-f2";
-    wait_still_screen(stilltime=>5, similarity_level=>45);
+    wait_still_screen(stilltime => 5, similarity_level => 45);
     # output location is different for cups-pdf 3.0.1-12 or later (we
     # checked this above)
     if ($cpdfvercmp eq "12") {
@@ -73,11 +73,11 @@ sub run {
     else {
         type_safely "$viewer /home/test/Desktop/testfile-job_1.pdf\n";
     }
-    wait_still_screen(stilltime=>5, similarity_level=>45);
+    wait_still_screen(stilltime => 5, similarity_level => 45);
     # Resize the window, so that the size of the document fits the bigger space
     # and gets more readable.
     send_key $maximize;
-    wait_still_screen(stilltime=>2, similarity_level=>45);
+    wait_still_screen(stilltime => 2, similarity_level => 45);
     # make sure we're at the start of the document
     send_key "ctrl-home" if ($desktop eq "kde");
     # Check the printed pdf.
@@ -86,7 +86,7 @@ sub run {
 
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/desktop_terminal.pm
+++ b/tests/desktop_terminal.pm
@@ -31,7 +31,7 @@ sub run {
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/desktop_update_graphical.pm
+++ b/tests/desktop_update_graphical.pm
@@ -10,7 +10,7 @@ sub run {
     my $relnum = get_release_number;
     my $version_major = get_version_major;
     # use a tty console for repo config and package prep
-    $self->root_console(tty=>3);
+    $self->root_console(tty => 3);
     assert_script_run 'dnf config-manager --set-disabled updates-testing';
     prepare_test_packages;
     # get back to the desktop
@@ -49,7 +49,7 @@ sub run {
     # may be waiting some time at a 'Software catalog is being
     # loaded' screen.
     if ($desktop eq 'gnome' || ($desktop eq 'kde' && $relnum > 33)) {
-        for my $n (1..5) {
+        for my $n (1 .. 5) {
             last if (check_screen 'desktop_package_tool_update', 120);
             mouse_set 10, 10;
             mouse_hide;
@@ -109,7 +109,7 @@ sub run {
         # FIXME: also sometimes the update apply button just doesn't
         # work, so keep clicking till it does:
         # https://bugzilla.redhat.com/show_bug.cgi?id=1943943
-        for my $n (1..10) {
+        for my $n (1 .. 10) {
             sleep 2;
             assert_screen ['kde_offline_update_reboot', 'desktop_package_tool_update_apply'];
             # break out if we reached the reboot button
@@ -127,12 +127,12 @@ sub run {
         assert_screen 'desktop_package_tool_update_done', 180;
     }
     # back to console to verify updates
-    $self->root_console(tty=>3);
+    $self->root_console(tty => 3);
     verify_updated_packages;
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/disk_custom_blivet_btrfs.pm
+++ b/tests/disk_custom_blivet_btrfs.pm
@@ -31,12 +31,12 @@ sub run {
     assert_and_click "anaconda_part_accept_changes";
 
     # Anaconda hub
-    assert_screen "anaconda_main_hub", 300; #
+    assert_screen "anaconda_main_hub", 300;    #
 
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/disk_custom_blivet_btrfs_preserve_home.pm
+++ b/tests/disk_custom_blivet_btrfs_preserve_home.pm
@@ -14,7 +14,7 @@ sub run {
     if (get_var("UEFI")) {
         # if we're running on UEFI, let us reformat the UEFI first
         # Select the UEFI partition if it is not selected by default
-        if (not (check_screen "anaconda_blivet_part_efi_selected", 30)) {
+        if (not(check_screen "anaconda_blivet_part_efi_selected", 30)) {
             assert_and_click "anaconda_blivet_part_inactive_efi";
             wait_still_screen 5;
         }
@@ -23,10 +23,10 @@ sub run {
         assert_and_click "anaconda_blivet_part_edit";
         # Select the Format option
         assert_and_click "anaconda_blivet_part_format";
-    if (not (check_screen "anaconda_blivet_part_fs_efi_filesystem_selected", 30)) {
-        assert_and_click "anaconda_blivet_part_fs_select";
-        assert_and_click "anaconda_blivet_part_fs_efi_filesystem";
-    }
+        if (not(check_screen "anaconda_blivet_part_fs_efi_filesystem_selected", 30)) {
+            assert_and_click "anaconda_blivet_part_fs_select";
+            assert_and_click "anaconda_blivet_part_fs_efi_filesystem";
+        }
         # Select the mountpoint field
 
         send_key_until_needlematch("anaconda_blivet_mountpoint_selected", "tab", 3, 5);
@@ -50,9 +50,9 @@ sub run {
     # Select the Format option
     assert_and_click "anaconda_blivet_part_format";
     # Open the filesystem types and select ext4, if not selected
-    if (not (check_screen "anaconda_blivet_part_fs_ext4_selected",30)) {
-            assert_and_click "anaconda_blivet_part_fs_select";
-            assert_and_click "anaconda_blivet_part_fs_ext4";
+    if (not(check_screen "anaconda_blivet_part_fs_ext4_selected", 30)) {
+        assert_and_click "anaconda_blivet_part_fs_select";
+        assert_and_click "anaconda_blivet_part_fs_ext4";
     }
     # Select the mountpoint field
     send_key_until_needlematch("anaconda_blivet_mountpoint_selected", "tab", 3, 5);
@@ -65,7 +65,7 @@ sub run {
     assert_and_click "anaconda_blivet_volumes_icon";
 
     # Select the home partition
-    if (not (check_screen "anaconda_blivet_part_home_selected")) {
+    if (not(check_screen "anaconda_blivet_part_home_selected")) {
         assert_and_click "anaconda_blivet_part_inactive_home";
     }
     # Go to the partition settings
@@ -87,7 +87,7 @@ sub run {
         assert_and_click "anaconda_blivet_part_root_exists";
         assert_and_click "anaconda_blivet_part_delete";
         assert_and_click "anaconda_blivet_btn_ok";
-    sleep 5;
+        sleep 5;
     }
 
     # Add new root partition
@@ -108,12 +108,12 @@ sub run {
     assert_and_click "anaconda_part_accept_changes";
 
     # Anaconda hub
-    assert_screen "anaconda_main_hub", 300; #
+    assert_screen "anaconda_main_hub", 300;    #
 
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/disk_custom_blivet_ext3.pm
+++ b/tests/disk_custom_blivet_ext3.pm
@@ -25,12 +25,12 @@ sub run {
     assert_and_click "anaconda_part_accept_changes";
 
     # Anaconda hub
-    assert_screen "anaconda_main_hub", 300; #
+    assert_screen "anaconda_main_hub", 300;    #
 
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/disk_custom_blivet_lvm_ext4.pm
+++ b/tests/disk_custom_blivet_lvm_ext4.pm
@@ -30,12 +30,12 @@ sub run {
     assert_and_click "anaconda_part_accept_changes";
 
     # Anaconda hub
-    assert_screen "anaconda_main_hub", 300; #
+    assert_screen "anaconda_main_hub", 300;    #
 
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/disk_custom_blivet_lvmthin.pm
+++ b/tests/disk_custom_blivet_lvmthin.pm
@@ -33,12 +33,12 @@ sub run {
     assert_and_click "anaconda_part_accept_changes";
 
     # Anaconda hub
-    assert_screen "anaconda_main_hub", 300; #
+    assert_screen "anaconda_main_hub", 300;    #
 
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/disk_custom_blivet_resize_lvm.pm
+++ b/tests/disk_custom_blivet_resize_lvm.pm
@@ -21,7 +21,7 @@ sub activate {
 
 sub run {
     my $self = shift;
-    # Navigate to "Installation destionation" and select blivet-gui 
+    # Navigate to "Installation destionation" and select blivet-gui
     # to manipulate the partitions. This will be automatically
     # done using the following method, because PARTITIONING starts
     # with "custom_blivet".
@@ -64,7 +64,7 @@ sub run {
     assert_screen "device_root_resized_thirteen";
 
     # Now format the resized root partition. It seems that the focus returns to the first
-    # partition in the view, so we need to activate this again before we attempt to do 
+    # partition in the view, so we need to activate this again before we attempt to do
     # anything to the partition.
     activate("root");
     custom_blivet_format_partition(type => 'ext4', label => 'root', mountpoint => '/');
@@ -86,7 +86,7 @@ sub run {
 }
 
 sub test_flags {
-        return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/disk_custom_blivet_software_raid.pm
+++ b/tests/disk_custom_blivet_software_raid.pm
@@ -7,7 +7,7 @@ sub run {
     my $self = shift;
     # Go to INSTALLATION DESTINATION and ensure two disks are selected.
     # Because PARTITIONING starts with 'custom_blivet', this will select blivet-gui.
-    select_disks(disks=>2);
+    select_disks(disks => 2);
     assert_and_click "anaconda_spoke_done";
 
     if (get_var("UEFI")) {
@@ -25,12 +25,12 @@ sub run {
     assert_and_click "anaconda_part_accept_changes";
 
     # Anaconda hub
-    assert_screen "anaconda_main_hub", 300; #
+    assert_screen "anaconda_main_hub", 300;    #
 
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/disk_custom_blivet_standard_partition_ext4.pm
+++ b/tests/disk_custom_blivet_standard_partition_ext4.pm
@@ -26,12 +26,12 @@ sub run {
     assert_and_click "anaconda_part_accept_changes";
 
     # Anaconda hub
-    assert_screen "anaconda_main_hub", 300; #
+    assert_screen "anaconda_main_hub", 300;    #
 
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/disk_custom_blivet_standard_partition_ext4_postinstall.pm
+++ b/tests/disk_custom_blivet_standard_partition_ext4_postinstall.pm
@@ -8,21 +8,21 @@ sub run {
     my $devroot = 'vda2';
     my $devboot = 'vda1';
     if (get_var('OFW') || get_var('UEFI')) {
-        $count = 4; # extra boot partition (PreP or ESP)
+        $count = 4;    # extra boot partition (PreP or ESP)
         $devroot = 'vda3';
         $devboot = 'vda2';
     }
     # check number of partitions
-    script_run 'fdisk -l | grep /dev/vda'; # debug
+    script_run 'fdisk -l | grep /dev/vda';    # debug
     validate_script_output 'fdisk -l | grep /dev/vda | wc -l', sub { $_ =~ m/$count/ };
     # check mounted partitions are ext4 fs
-    script_run 'mount | grep /dev/vda'; # debug
+    script_run 'mount | grep /dev/vda';    # debug
     validate_script_output "mount | grep /dev/$devboot", sub { $_ =~ m/on \/boot type ext4/ };
     validate_script_output "mount | grep /dev/$devroot", sub { $_ =~ m/on \/ type ext4/ };
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/disk_custom_blivet_with_swap.pm
+++ b/tests/disk_custom_blivet_with_swap.pm
@@ -26,12 +26,12 @@ sub run {
     assert_and_click "anaconda_part_accept_changes";
 
     # Anaconda hub
-    assert_screen "anaconda_main_hub", 300; #
+    assert_screen "anaconda_main_hub", 300;    #
 
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/disk_custom_blivet_xfs.pm
+++ b/tests/disk_custom_blivet_xfs.pm
@@ -25,12 +25,12 @@ sub run {
     assert_and_click "anaconda_part_accept_changes";
 
     # Anaconda hub
-    assert_screen "anaconda_main_hub", 300; #
+    assert_screen "anaconda_main_hub", 300;    #
 
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/disk_custom_btrfs.pm
+++ b/tests/disk_custom_btrfs.pm
@@ -19,12 +19,12 @@ sub run {
     assert_and_click "anaconda_part_accept_changes";
 
     # Anaconda hub
-    assert_screen "anaconda_main_hub", 300; #
+    assert_screen "anaconda_main_hub", 300;    #
 
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/disk_custom_btrfs_postinstall.pm
+++ b/tests/disk_custom_btrfs_postinstall.pm
@@ -9,7 +9,7 @@ sub run {
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/disk_custom_btrfs_preserve_home.pm
+++ b/tests/disk_custom_btrfs_preserve_home.pm
@@ -67,12 +67,12 @@ sub run {
     assert_and_click "anaconda_part_accept_changes";
 
     # Anaconda hub
-    assert_screen "anaconda_main_hub", 300; #
+    assert_screen "anaconda_main_hub", 300;    #
 
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/disk_custom_ext3.pm
+++ b/tests/disk_custom_ext3.pm
@@ -21,12 +21,12 @@ sub run {
     assert_and_click "anaconda_part_accept_changes";
 
     # Anaconda hub
-    assert_screen "anaconda_main_hub", 300; #
+    assert_screen "anaconda_main_hub", 300;    #
 
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/disk_custom_ext3_postinstall.pm
+++ b/tests/disk_custom_ext3_postinstall.pm
@@ -9,7 +9,7 @@ sub run {
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/disk_custom_gui_lvm_ext4.pm
+++ b/tests/disk_custom_gui_lvm_ext4.pm
@@ -30,12 +30,12 @@ sub run {
     assert_and_click "anaconda_part_accept_changes";
 
     # Anaconda hub
-    assert_screen "anaconda_main_hub", 300; #
+    assert_screen "anaconda_main_hub", 300;    #
 
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/disk_custom_gui_software_raid.pm
+++ b/tests/disk_custom_gui_software_raid.pm
@@ -7,7 +7,7 @@ sub run {
     my $self = shift;
     # Go to INSTALLATION DESTINATION and ensure two disks are selected.
     # Because PARTITIONING starts with 'custom', this will select blivet-gui.
-    select_disks(disks=>2);
+    select_disks(disks => 2);
     assert_and_click "anaconda_spoke_done";
 
     if (get_var("UEFI")) {
@@ -26,12 +26,12 @@ sub run {
     assert_and_click "anaconda_part_accept_changes";
 
     # Anaconda hub
-    assert_screen "anaconda_main_hub", 300; #
+    assert_screen "anaconda_main_hub", 300;    #
 
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/disk_custom_gui_standard_partition_ext4.pm
+++ b/tests/disk_custom_gui_standard_partition_ext4.pm
@@ -27,12 +27,12 @@ sub run {
     assert_and_click "anaconda_part_accept_changes";
 
     # Anaconda hub
-    assert_screen "anaconda_main_hub", 300; #
+    assert_screen "anaconda_main_hub", 300;    #
 
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/disk_custom_gui_xfs.pm
+++ b/tests/disk_custom_gui_xfs.pm
@@ -26,12 +26,12 @@ sub run {
     assert_and_click "anaconda_part_accept_changes";
 
     # Anaconda hub
-    assert_screen "anaconda_main_hub", 300; #
+    assert_screen "anaconda_main_hub", 300;    #
 
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/disk_custom_iscsi.pm
+++ b/tests/disk_custom_iscsi.pm
@@ -11,7 +11,7 @@ sub run {
     # Anaconda hub
     # Go to INSTALLATION DESTINATION and ensure one regular disk
     # and the iscsi target are selected.
-    select_disks(iscsi=>\%iscsi);
+    select_disks(iscsi => \%iscsi);
     assert_and_click "anaconda_spoke_done";
     # now we're at custom part. let's use standard partitioning for
     # simplicity
@@ -25,7 +25,7 @@ sub run {
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/disk_custom_iscsi_postinstall.pm
+++ b/tests/disk_custom_iscsi_postinstall.pm
@@ -12,7 +12,7 @@ sub run {
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/disk_custom_lvm_ext4.pm
+++ b/tests/disk_custom_lvm_ext4.pm
@@ -23,12 +23,12 @@ sub run {
     assert_and_click "anaconda_part_accept_changes";
 
     # Anaconda hub
-    assert_screen "anaconda_main_hub", 300; #
+    assert_screen "anaconda_main_hub", 300;    #
 
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/disk_custom_lvm_ext4_postinstall.pm
+++ b/tests/disk_custom_lvm_ext4_postinstall.pm
@@ -6,7 +6,7 @@ use utils;
 sub run {
     my $self = shift;
     unless (check_screen "root_console", 0) {
-        $self->root_console(tty=>4);
+        $self->root_console(tty => 4);
     }
     assert_screen "root_console";
     my $devboot = 'vda1';
@@ -29,7 +29,7 @@ sub run {
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/disk_custom_lvmthin.pm
+++ b/tests/disk_custom_lvmthin.pm
@@ -19,12 +19,12 @@ sub run {
     assert_and_click "anaconda_part_accept_changes";
 
     # Anaconda hub
-    assert_screen "anaconda_main_hub", 300; #
+    assert_screen "anaconda_main_hub", 300;    #
 
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/disk_custom_lvmthin_postinstall.pm
+++ b/tests/disk_custom_lvmthin_postinstall.pm
@@ -6,7 +6,7 @@ use utils;
 sub run {
     my $self = shift;
     unless (check_screen "root_console", 0) {
-        $self->root_console(tty=>4);
+        $self->root_console(tty => 4);
     }
     assert_screen "root_console";
     # check that lvmthinpool is present:
@@ -16,7 +16,7 @@ sub run {
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/disk_custom_resize_lvm.pm
+++ b/tests/disk_custom_resize_lvm.pm
@@ -10,7 +10,7 @@ sub goto_mountpoint {
 
 sub run {
     my $self = shift;
-    # Navigate to "Installation destionation" and select blivet-gui 
+    # Navigate to "Installation destionation" and select blivet-gui
     # to manipulate the partitions. This will be automatically
     # done using the following method, because PARTITIONING starts
     # with "custom_blivet".
@@ -21,7 +21,7 @@ sub run {
     # a previous Linux installation and prepare the disk for new installation
     # which will be then followed through.
 
-    # Custom partitioning shows that an existing installations is there on the disk, 
+    # Custom partitioning shows that an existing installations is there on the disk,
     # we need to select it to proceed.
     assert_and_click "anaconda_part_use_current";
 
@@ -86,7 +86,7 @@ sub run {
 }
 
 sub test_flags {
-        return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/disk_custom_resize_lvm_postinstall.pm
+++ b/tests/disk_custom_resize_lvm_postinstall.pm
@@ -10,7 +10,7 @@ sub run {
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/disk_custom_software_raid.pm
+++ b/tests/disk_custom_software_raid.pm
@@ -7,7 +7,7 @@ sub run {
     my $self = shift;
     # Go to INSTALLATION DESTINATION and ensure two disks are selected.
     # Because PARTITIONING starts with 'custom_', this will select custom.
-    select_disks(disks=>2);
+    select_disks(disks => 2);
     assert_and_click "anaconda_spoke_done";
 
     # Manual partitioning spoke should be displayed
@@ -17,12 +17,12 @@ sub run {
     assert_and_click "anaconda_part_accept_changes";
 
     # Anaconda hub
-    assert_screen "anaconda_main_hub", 300; #
+    assert_screen "anaconda_main_hub", 300;    #
 
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/disk_custom_software_raid_postinstall.pm
+++ b/tests/disk_custom_software_raid_postinstall.pm
@@ -6,7 +6,7 @@ use utils;
 sub run {
     my $self = shift;
     unless (check_screen "root_console", 0) {
-        $self->root_console(tty=>4);
+        $self->root_console(tty => 4);
     }
     assert_screen "root_console";
     # check that RAID is used
@@ -14,7 +14,7 @@ sub run {
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/disk_custom_standard_partition_ext4.pm
+++ b/tests/disk_custom_standard_partition_ext4.pm
@@ -10,25 +10,25 @@ sub run {
     select_disks();
     assert_and_click "anaconda_spoke_done";
 
-    # Manual partitioning spoke should be displayed. 
+    # Manual partitioning spoke should be displayed.
     # Select the Standard Partitioning scheme
     custom_scheme_select("standard");
     # Do 'automatic' partition creation
     assert_and_click "anaconda_part_automatic";
     # Select ext4 as filesystems for partitions
-    custom_change_fs("ext4","root");
-    custom_change_fs("ext4","boot");
+    custom_change_fs("ext4", "root");
+    custom_change_fs("ext4", "boot");
     # Finish the settings
     assert_and_click "anaconda_spoke_done";
     assert_and_click "anaconda_part_accept_changes";
 
     # Anaconda hub
-    assert_screen "anaconda_main_hub", 300; #
+    assert_screen "anaconda_main_hub", 300;    #
 
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/disk_custom_standard_partition_ext4_postinstall.pm
+++ b/tests/disk_custom_standard_partition_ext4_postinstall.pm
@@ -6,7 +6,7 @@ use utils;
 sub run {
     my $self = shift;
     unless (check_screen "root_console", 0) {
-        $self->root_console(tty=>4);
+        $self->root_console(tty => 4);
     }
     assert_screen "root_console";
     my $count = 4;
@@ -14,23 +14,23 @@ sub run {
     my $devswap = 'vda2';
     my $devboot = 'vda3';
     if (get_var('OFW') || get_var('UEFI')) {
-        $count = 5; # extra boot partition (PreP or ESP)
+        $count = 5;    # extra boot partition (PreP or ESP)
         $devroot = 'vda2';
         $devswap = 'vda3';
         $devboot = 'vda4';
     }
     # check number of partitions
-    script_run 'fdisk -l | grep /dev/vda'; # debug
+    script_run 'fdisk -l | grep /dev/vda';    # debug
     validate_script_output 'fdisk -l | grep /dev/vda | wc -l', sub { $_ =~ m/$count/ };
     # check mounted partitions are ext4 fs
-    script_run 'mount | grep /dev/vda'; # debug
+    script_run 'mount | grep /dev/vda';    # debug
     validate_script_output "mount | grep /dev/$devboot", sub { $_ =~ m/on \/boot type ext4/ };
     validate_script_output "mount | grep /dev/$devroot", sub { $_ =~ m/on \/ type ext4/ };
     validate_script_output "swapon --show | grep /dev/$devswap", sub { $_ =~ m/ partition / };
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/disk_custom_with_swap.pm
+++ b/tests/disk_custom_with_swap.pm
@@ -29,12 +29,12 @@ sub run {
     assert_and_click "anaconda_part_accept_changes";
 
     # Anaconda hub
-    assert_screen "anaconda_main_hub", 300; #
+    assert_screen "anaconda_main_hub", 300;    #
 
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/disk_custom_with_swap_postinstall.pm
+++ b/tests/disk_custom_with_swap_postinstall.pm
@@ -11,7 +11,7 @@ sub run {
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/disk_custom_xfs.pm
+++ b/tests/disk_custom_xfs.pm
@@ -21,12 +21,12 @@ sub run {
     assert_and_click "anaconda_part_accept_changes";
 
     # Anaconda hub
-    assert_screen "anaconda_main_hub", 300; #
+    assert_screen "anaconda_main_hub", 300;    #
 
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/disk_custom_xfs_postinstall.pm
+++ b/tests/disk_custom_xfs_postinstall.pm
@@ -9,7 +9,7 @@ sub run {
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/disk_guided_delete_all.pm
+++ b/tests/disk_guided_delete_all.pm
@@ -18,12 +18,12 @@ sub run {
     assert_and_click "anaconda_install_destination_reclaim_space_btn";
 
     # Anaconda hub
-    assert_screen "anaconda_main_hub", 300; #
+    assert_screen "anaconda_main_hub", 300;    #
 
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/disk_guided_delete_partial.pm
+++ b/tests/disk_guided_delete_partial.pm
@@ -22,12 +22,12 @@ sub run {
     assert_and_click "anaconda_install_destination_reclaim_space_btn";
 
     # Anaconda hub
-    assert_screen "anaconda_main_hub", 300; #
+    assert_screen "anaconda_main_hub", 300;    #
 
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/disk_guided_delete_partial_postinstall.pm
+++ b/tests/disk_guided_delete_partial_postinstall.pm
@@ -10,7 +10,7 @@ sub run {
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/disk_guided_empty.pm
+++ b/tests/disk_guided_empty.pm
@@ -15,18 +15,18 @@ sub run {
 
     # updates.img tests work by changing the appearance of the INSTALLATION
     # DESTINATION screen, so check that if needed.
-    if (get_var('TEST_UPDATES')){
+    if (get_var('TEST_UPDATES')) {
         assert_screen "anaconda_install_destination_updates", 30;
     }
     # Here the self identification test code is placed.
     my $branched = get_var('VERSION');
     if ($identification eq 'true' or $branched ne "Rawhide") {
-        check_top_bar(); # See utils.pm
-        # we don't check version or pre-release because here those
-        # texts appear on the banner which makes the needling
-        # complex and fragile (banner is different between variants,
-        # and has a gradient so for RTL languages the background color
-        # differs; pre-release text is also translated)
+        check_top_bar();    # See utils.pm
+                            # we don't check version or pre-release because here those
+                            # texts appear on the banner which makes the needling
+                            # complex and fragile (banner is different between variants,
+                            # and has a gradient so for RTL languages the background color
+                            # differs; pre-release text is also translated)
     }
 
     assert_and_click "anaconda_spoke_done";
@@ -46,12 +46,12 @@ sub run {
     }
 
     # Anaconda hub
-    assert_screen "anaconda_main_hub", 300; #
+    assert_screen "anaconda_main_hub", 300;    #
 
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/disk_guided_encrypted.pm
+++ b/tests/disk_guided_encrypted.pm
@@ -30,12 +30,12 @@ sub run {
     assert_and_click "anaconda_install_destination_save_passphrase";
 
     # Anaconda hub
-    assert_screen "anaconda_main_hub", 300; #
+    assert_screen "anaconda_main_hub", 300;    #
 
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/disk_guided_encrypted_postinstall.pm
+++ b/tests/disk_guided_encrypted_postinstall.pm
@@ -14,7 +14,7 @@ sub run {
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/disk_guided_free_space_postinstall.pm
+++ b/tests/disk_guided_free_space_postinstall.pm
@@ -10,7 +10,7 @@ sub run {
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/disk_guided_multi.pm
+++ b/tests/disk_guided_multi.pm
@@ -7,16 +7,16 @@ sub run {
     my $self = shift;
     # Anaconda hub
     # Go to INSTALLATION DESTINATION and select only one disk.
-    select_disks(disks=>1);
+    select_disks(disks => 1);
     assert_and_click "anaconda_spoke_done";
 
     # Anaconda hub
-    assert_screen "anaconda_main_hub", 300; #
+    assert_screen "anaconda_main_hub", 300;    #
 
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/disk_guided_multi_empty_all.pm
+++ b/tests/disk_guided_multi_empty_all.pm
@@ -7,16 +7,16 @@ sub run {
     my $self = shift;
     # Anaconda hub
     # Go to INSTALLATION DESTINATION and select two disks.
-    select_disks(disks=>2);
+    select_disks(disks => 2);
     assert_and_click "anaconda_spoke_done";
 
     # Anaconda hub
-    assert_screen "anaconda_main_hub", 300; #
+    assert_screen "anaconda_main_hub", 300;    #
 
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/disk_guided_multi_empty_all_postinstall.pm
+++ b/tests/disk_guided_multi_empty_all_postinstall.pm
@@ -10,7 +10,7 @@ sub run {
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/disk_guided_multi_postinstall.pm
+++ b/tests/disk_guided_multi_postinstall.pm
@@ -10,7 +10,7 @@ sub run {
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/disk_guided_shrink.pm
+++ b/tests/disk_guided_shrink.pm
@@ -23,12 +23,12 @@ sub run {
     assert_and_click "anaconda_install_destination_reclaim_space_btn";
 
     # Anaconda hub
-    assert_screen "anaconda_main_hub", 300; #
+    assert_screen "anaconda_main_hub", 300;    #
 
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/disk_guided_shrink_postinstall.pm
+++ b/tests/disk_guided_shrink_postinstall.pm
@@ -10,7 +10,7 @@ sub run {
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/firewall_configured.pm
+++ b/tests/firewall_configured.pm
@@ -3,9 +3,9 @@ use strict;
 use testapi;
 
 sub run {
-    my $self=shift;
-    if (not( check_screen "root_console", 0)) {
-        $self->root_console(tty=>3);
+    my $self = shift;
+    if (not(check_screen "root_console", 0)) {
+        $self->root_console(tty => 3);
     }
     # this only succeeds if the firewall is running
     assert_script_run 'firewall-cmd --state';
@@ -17,7 +17,7 @@ sub run {
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/firewall_disabled.pm
+++ b/tests/firewall_disabled.pm
@@ -3,9 +3,9 @@ use strict;
 use testapi;
 
 sub run {
-    my $self=shift;
-    if (not( check_screen "root_console", 0)) {
-        $self->root_console(tty=>3);
+    my $self = shift;
+    if (not(check_screen "root_console", 0)) {
+        $self->root_console(tty => 3);
     }
     # this asserts that the command fails (which it does when fw is not running)
     assert_script_run '! firewall-cmd --state';
@@ -14,7 +14,7 @@ sub run {
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/freeipa_client.pm
+++ b/tests/freeipa_client.pm
@@ -4,7 +4,7 @@ use testapi;
 use utils;
 
 sub run {
-    my $self=shift;
+    my $self = shift;
     # switch to tty1 (we're usually there already, but just in case
     # we're carrying on from a failed freeipa_webui that didn't fail
     # at tty1)
@@ -25,7 +25,7 @@ sub run {
     # switch to tty2 for login tests
     send_key "ctrl-alt-f2";
     # try and login as test1, should work
-    console_login(user=>'test1@TEST.OPENQA.FEDORAPROJECT.ORG', password=>'batterystaple');
+    console_login(user => 'test1@TEST.OPENQA.FEDORAPROJECT.ORG', password => 'batterystaple');
     type_string "exit\n";
     # try and login as test2, should fail. we cannot use console_login
     # as it takes 10 seconds to complete when login fails, and
@@ -40,7 +40,7 @@ sub run {
 
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/freeipa_password_change.pm
+++ b/tests/freeipa_password_change.pm
@@ -6,7 +6,7 @@ use freeipa;
 
 sub run {
     my $self = shift;
-    console_login(user=>'root');
+    console_login(user => 'root');
     # check whether test3 exists, i.e. whether freeipa_webui at
     # least managed to create it. if not, we may as well just
     # die now, this test cannot work.
@@ -60,7 +60,7 @@ sub run {
 }
 
 sub test_flags {
-    return { 'ignore_failure' => 1 };
+    return {'ignore_failure' => 1};
 }
 
 1;

--- a/tests/freeipa_webui.pm
+++ b/tests/freeipa_webui.pm
@@ -53,7 +53,7 @@ sub run {
     # switch to tty4 (boy, the tty jugglin')
     send_key "ctrl-alt-f4";
     # try and login as test3, should work
-    console_login(user=>'test3@TEST.OPENQA.FEDORAPROJECT.ORG', password=>'batterystaple');
+    console_login(user => 'test3@TEST.OPENQA.FEDORAPROJECT.ORG', password => 'batterystaple');
     type_string "exit\n";
     # try and login as test4, should fail. we cannot use console_login
     # as it takes 10 seconds to complete when login fails, and
@@ -69,7 +69,7 @@ sub run {
 }
 
 sub test_flags {
-    return { 'ignore_failure' => 1 };
+    return {'ignore_failure' => 1};
 }
 
 1;

--- a/tests/install_source_graphical.pm
+++ b/tests/install_source_graphical.pm
@@ -8,7 +8,7 @@ use Time::HiRes qw( usleep );
 sub run {
     my $self = shift;
     # Anaconda hub
-    assert_screen "anaconda_main_hub", 300; #
+    assert_screen "anaconda_main_hub", 300;    #
 
     # Go into the Install Source spoke
     assert_and_click "anaconda_main_hub_installation_source";
@@ -26,7 +26,7 @@ sub run {
     if (get_var("REPOSITORY_GRAPHICAL") =~ m/^http:/) {
         $num = 4;
     }
-    for (my $i=0; $i<$num; $i++) {
+    for (my $i = 0; $i < $num; $i++) {
         send_key "up";
         usleep 100;
     }
@@ -77,7 +77,7 @@ sub run {
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/install_text.pm
+++ b/tests/install_text.pm
@@ -62,69 +62,69 @@ sub run {
 
     if (get_var("DISTRI") eq "rocky") {
         # Activate Network
-        run_with_error_check(sub {console_type_wait($spoke_number{"network"} . "\n")}, $error);
-        console_type_wait("2\n"); # Configure device
-        console_type_wait("7\n"); # Connect automatically after reboot
-        console_type_wait("8\n"); # Apply configuration in installer
-        console_type_wait("c\n"); # Continue
+        run_with_error_check(sub { console_type_wait($spoke_number{"network"} . "\n") }, $error);
+        console_type_wait("2\n");    # Configure device
+        console_type_wait("7\n");    # Connect automatically after reboot
+        console_type_wait("8\n");    # Apply configuration in installer
+        console_type_wait("c\n");    # Continue
         sleep 10;
-        console_type_wait("r\n"); # Refresh
-        console_type_wait("c\n"); # Continue
+        console_type_wait("r\n");    # Refresh
+        console_type_wait("c\n");    # Continue
 
         # Software Selection
-        run_with_error_check(sub {console_type_wait($spoke_number{"swselection"} . "\n")}, $error);
-        console_type_wait("2\n"); # Server
-        console_type_wait("c\n"); # Continue
-        console_type_wait("c\n"); # Continue
+        run_with_error_check(sub { console_type_wait($spoke_number{"swselection"} . "\n") }, $error);
+        console_type_wait("2\n");    # Server
+        console_type_wait("c\n");    # Continue
+        console_type_wait("c\n");    # Continue
         sleep 10;
-        console_type_wait("r\n"); # Refresh
+        console_type_wait("r\n");    # Refresh
     }
 
     # Set timezone
-    run_with_error_check(sub {console_type_wait($spoke_number{"timezone"} . "\n")}, $error);
-    console_type_wait("1\n"); # Set timezone
-    console_type_wait("1\n"); # Europe
-    console_type_wait("37\n", 7); # Prague
+    run_with_error_check(sub { console_type_wait($spoke_number{"timezone"} . "\n") }, $error);
+    console_type_wait("1\n");    # Set timezone
+    console_type_wait("1\n");    # Europe
+    console_type_wait("37\n", 7);    # Prague
 
     # Select disk
-    run_with_error_check(sub {console_type_wait($spoke_number{"destination"} . "\n")}, $error);
-    console_type_wait("c\n"); # first disk selected, continue
-    console_type_wait("c\n"); # use all space selected, continue
-    console_type_wait("c\n", 7); # LVM selected, continue
+    run_with_error_check(sub { console_type_wait($spoke_number{"destination"} . "\n") }, $error);
+    console_type_wait("c\n");    # first disk selected, continue
+    console_type_wait("c\n");    # use all space selected, continue
+    console_type_wait("c\n", 7);    # LVM selected, continue
 
     # Set root password
     my $rootpwd = get_var("ROOT_PASSWORD", "weakpassword");
-    run_with_error_check(sub {console_type_wait($spoke_number{"rootpwd"} . "\n")}, $error);
+    run_with_error_check(sub { console_type_wait($spoke_number{"rootpwd"} . "\n") }, $error);
     console_type_wait("$rootpwd\n");
     console_type_wait("$rootpwd\n");
 
     # Create user
     my $userpwd = get_var("USER_PASSWORD", "weakpassword");
     my $username = get_var("USER_LOGIN", "test");
-    run_with_error_check(sub {console_type_wait($spoke_number{"user"} . "\n")}, $error);
-    console_type_wait("1\n"); # create new
-    console_type_wait("3\n"); # set username
+    run_with_error_check(sub { console_type_wait($spoke_number{"user"} . "\n") }, $error);
+    console_type_wait("1\n");    # create new
+    console_type_wait("3\n");    # set username
     console_type_wait("$username\n");
     # from Rawhide-20190503.n.0 (F31) onwards, 'use password' is default
     if ((get_release_number() < 31) || (get_version_major() < 9)) {
         # typing "4\n" on abrt screen causes system to reboot, so be careful
-        run_with_error_check(sub {console_type_wait("4\n")}, $error); # use password
+        run_with_error_check(sub { console_type_wait("4\n") }, $error);    # use password
     }
-    console_type_wait("5\n"); # set password
+    console_type_wait("5\n");    # set password
     console_type_wait("$userpwd\n");
     console_type_wait("$userpwd\n");
-    console_type_wait("6\n"); # make him an administrator
+    console_type_wait("6\n");    # make him an administrator
     console_type_wait("c\n", 7);
 
     my $counter = 0;
     if (testapi::is_serial_terminal) {
-        while (wait_serial("[!]", timeout=>5, quiet=>1)) {
+        while (wait_serial("[!]", timeout => 5, quiet => 1)) {
             if ($counter > 10) {
                 die "There are unfinished spokes in Anaconda";
             }
             sleep 10;
             $counter++;
-            console_type_wait("r\n"); # refresh
+            console_type_wait("r\n");    # refresh
         }
     }
     else {
@@ -134,7 +134,7 @@ sub run {
             }
             sleep 10;
             $counter++;
-            console_type_wait("r\n"); # refresh
+            console_type_wait("r\n");    # refresh
         }
     }
 
@@ -157,7 +157,7 @@ sub run {
     }
 
     if (testapi::is_serial_terminal) {
-        wait_serial("Installation complete", timeout=>$timeout);
+        wait_serial("Installation complete", timeout => $timeout);
         if (get_var("SERIAL_CONSOLE") && get_var("OFW")) {
             # for some reason the check for a prompt times out here, even
             # though '# ' is clearly in the terminal log; hack it out
@@ -181,7 +181,7 @@ sub run {
 
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/iot_clevis.pm
+++ b/tests/iot_clevis.pm
@@ -23,7 +23,7 @@ sub run {
 
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/iot_greenboot.pm
+++ b/tests/iot_greenboot.pm
@@ -6,7 +6,7 @@ use utils;
 sub run {
     my $self = shift;
     # switch to TTY3 for both, graphical and console tests
-    $self->root_console(tty=>3);
+    $self->root_console(tty => 3);
 
     # Use ssh to log into this machine to see its status.
     type_string "ssh test\@localhost\n";
@@ -29,7 +29,7 @@ sub run {
 
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/iot_rpmostree_overlay.pm
+++ b/tests/iot_rpmostree_overlay.pm
@@ -8,7 +8,7 @@ sub reboot_and_login {
     my $reboot_time = shift;
     script_run "systemctl reboot";
     boot_to_login_screen(timeout => $reboot_time);
-    console_login(user=>"root", password=>get_var("ROOT_PASSWORD"));
+    console_login(user => "root", password => get_var("ROOT_PASSWORD"));
     sleep 2;
 }
 
@@ -16,14 +16,14 @@ sub run {
     my $self = shift;
     my $reboot_time = 300;
     # switch to TTY3 for both, graphical and console tests
-    $self->root_console(tty=>3);
+    $self->root_console(tty => 3);
 
     # Install wget as rpm-ostree overlay. Let's have timeout defined
     # quite generously, because it loads the package DBs.
     assert_script_run "rpm-ostree install wget", timeout => 300;
     # Reboot the machine to boot into the overlayed tree.
     reboot_and_login "300";
-    
+
     # Check that wget rpm is installed
     assert_script_run "rpm -q wget";
     # And that it works
@@ -31,7 +31,7 @@ sub run {
 
     # Then install the httpd package.
     assert_script_run "rpm-ostree install httpd", timeout => 300;
-    
+
     # Reboot the machine to boot into the overlayed tree.
     reboot_and_login "300";
 
@@ -46,7 +46,7 @@ sub run {
 
     # Check for the functional test page
     assert_script_run "curl -o page.html http://localhost";
-    assert_script_run "grep 'Fedora Project' page.html"; 
+    assert_script_run "grep 'Fedora Project' page.html";
 
     # Enable the httpd service
     assert_script_run "systemctl enable httpd";
@@ -73,7 +73,7 @@ sub run {
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/iot_rpmostree_rebase.pm
+++ b/tests/iot_rpmostree_rebase.pm
@@ -6,7 +6,7 @@ use utils;
 sub run {
 
     my $self = shift;
-    $self->root_console(tty=>3);
+    $self->root_console(tty => 3);
 
     # list available branches
     assert_script_run "ostree remote refs fedora-iot";
@@ -19,14 +19,14 @@ sub run {
 
     # if testing the current release, rebase to devel
     unless (script_run "rpm-ostree status -b | grep stable") {
-        $rebase = "devel"
+        $rebase = "devel";
     }
     # rebase to the appropriate release, arch
     validate_script_output "rpm-ostree rebase fedora/${rebase}/${arch}/iot", sub { m/systemctl reboot/ }, 300;
     script_run "systemctl reboot", 0;
 
     boot_to_login_screen;
-    $self->root_console(tty=>3);
+    $self->root_console(tty => 3);
 
     # check booted branch to make sure successful rebase
     if ($rebase eq "devel") {
@@ -41,7 +41,7 @@ sub run {
     script_run "systemctl reboot", 0;
 
     boot_to_login_screen;
-    $self->root_console(tty=>3);
+    $self->root_console(tty => 3);
 
     # check to make sure rollback successful, also account for branched (devel)
     if ($rebase eq "devel") {
@@ -53,7 +53,7 @@ sub run {
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/iot_zezere_ignition.pm
+++ b/tests/iot_zezere_ignition.pm
@@ -11,7 +11,7 @@ sub run {
 
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/mediakit_fileconflicts.pm
+++ b/tests/mediakit_fileconflicts.pm
@@ -15,7 +15,7 @@ sub run {
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/mediakit_repoclosure.pm
+++ b/tests/mediakit_repoclosure.pm
@@ -13,7 +13,7 @@ sub run {
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/memtest.pm
+++ b/tests/memtest.pm
@@ -9,7 +9,7 @@ use utils;
 #
 
 sub run {
-    
+
     # Let's navigate through the Grub menu and choose the memtest item.
     # We use plenty of sleeps to slower down the process a little bit
     # and to make it visible at the video and for some troubleshooting.
@@ -27,7 +27,7 @@ sub run {
     send_key "down";
     sleep 1;
     send_key "ret";
-    # Now Memtest should be running. 
+    # Now Memtest should be running.
     send_key "f1";
     # Assert that the test has reached 10%
     assert_screen "memtest_ten_percent", 120;

--- a/tests/modularity_checkdefaults.pm
+++ b/tests/modularity_checkdefaults.pm
@@ -3,9 +3,9 @@ use strict;
 use testapi;
 use utils;
 sub run {
-    my $self=shift;
+    my $self = shift;
     # switch to tty and login as root
-    $self->root_console(tty=>3);
+    $self->root_console(tty => 3);
 
     # Download the testing script
     download_modularity_tests('whitelist');
@@ -14,7 +14,7 @@ sub run {
     assert_script_run('/root/test.py -a checkdefaults -w whitelist');
 
     # Upload modular logs
-    upload_logs '/root/modular.log', failok=>1;
+    upload_logs '/root/modular.log', failok => 1;
 }
 
 1;

--- a/tests/modularity_enable_disable_module.pm
+++ b/tests/modularity_enable_disable_module.pm
@@ -5,10 +5,10 @@ use testapi;
 use utils;
 
 sub run {
-    my $self=shift;
+    my $self = shift;
     my $hook_run = 0;
     # switch to tty and login as root
-    $self->root_console(tty=>3);
+    $self->root_console(tty => 3);
 
     # Enable the module.
     my $name = "swig";
@@ -28,7 +28,7 @@ sub run {
     if (is_listed($name, $stream, \@disabled_modules)) {
         die "The enabled module is listed in the list of disabled modules but it should not be.";
     }
-    
+
     # Disable some other module.
     my $name_alt = "postgresql";
     my $stream_alt = "13";
@@ -50,7 +50,7 @@ sub run {
 
     # Reset the first module to its original state and do the list checks.
     assert_script_run("dnf module reset -y $name");
-    
+
     # Check that the module has disappeared from both the lists.
     $disabled = script_output('dnf module list --disabled');
     @disabled_modules = parse_module_list($disabled);

--- a/tests/modularity_install_module.pm
+++ b/tests/modularity_install_module.pm
@@ -5,9 +5,9 @@ use testapi;
 use utils;
 
 sub run {
-    my $self=shift;
+    my $self = shift;
     # switch to tty and login as root
-    $self->root_console(tty=>3);
+    $self->root_console(tty => 3);
 
     # Install a Ruby module.
     my $name = "nodejs";
@@ -30,7 +30,7 @@ sub run {
     unless ($found) {
         die "The installed module is not listed in the list of enabled modules but it should be.";
     }
-    
+
     # Remove the module again.
     assert_script_run("dnf module remove -y $name:$stream");
 

--- a/tests/modularity_module_list.pm
+++ b/tests/modularity_module_list.pm
@@ -5,9 +5,9 @@ use testapi;
 use utils;
 
 sub run {
-    my $self=shift;
+    my $self = shift;
     # switch to tty and login as root
-    $self->root_console(tty=>3);
+    $self->root_console(tty => 3);
 
     # The test case will check that dnf has modular functions and that
     # it is possible to invoke modular commands to work with modularity.

--- a/tests/modularity_update_norepo.pm
+++ b/tests/modularity_update_norepo.pm
@@ -5,9 +5,9 @@ use utils;
 use modularity;
 
 sub run {
-    my $self=shift;
+    my $self = shift;
     # switch to tty and login as root
-    $self->root_console(tty=>3);
+    $self->root_console(tty => 3);
 
     # Update the system
     assert_script_run('dnf update -y');

--- a/tests/os_release.pm
+++ b/tests/os_release.pm
@@ -6,107 +6,107 @@ use utils;
 # This test checks that the descriptions in /etc/os-release file are correct and that they
 # match the current version.
 sub strip_marks {
-        # Remove the quotation marks from the string:
-        my $string = shift;
-        $string=~ tr/"//d;
-        return $string;
+    # Remove the quotation marks from the string:
+    my $string = shift;
+    $string =~ tr/"//d;
+    return $string;
 }
 
 sub run {
-        # First, let us define some variables needed to run the program.
-        my $self = shift;
-        # The file to be checked
-        my $filename = '/etc/os-release';
+    # First, let us define some variables needed to run the program.
+    my $self = shift;
+    # The file to be checked
+    my $filename = '/etc/os-release';
 
-        # Read the content of the file to compare. Let us parse the file
-        # and create a hash with those values, so that we can easily access
-        # them and assert them.
-        my $infile = script_output "cat /etc/os-release";
-        my @infile = split /\n/, $infile;
-        my %content = ();
-        foreach (@infile) {
-                chomp $_;
-                my ($key, $value) = split /=/, $_;
-                $content{$key} = $value;
-        }
+    # Read the content of the file to compare. Let us parse the file
+    # and create a hash with those values, so that we can easily access
+    # them and assert them.
+    my $infile = script_output "cat /etc/os-release";
+    my @infile = split /\n/, $infile;
+    my %content = ();
+    foreach (@infile) {
+        chomp $_;
+        my ($key, $value) = split /=/, $_;
+        $content{$key} = $value;
+    }
 
-        # Now, we have all the data ready and we can start testing, first let us get
-        # correct variables to compare the system data with.
-        # First, we know the basic stuff
-        my $id = get_var("DISTRI"); # Should be "rocky"
+    # Now, we have all the data ready and we can start testing, first let us get
+    # correct variables to compare the system data with.
+    # First, we know the basic stuff
+    my $id = get_var("DISTRI");    # Should be "rocky"
 
-        my $name = ucfirst($id);
-        # $NAME is "Rocky Linux" not just "Rocky"
-        my $fullname = $name . " Linux";
+    my $name = ucfirst($id);
+    # $NAME is "Rocky Linux" not just "Rocky"
+    my $fullname = $name . " Linux";
 
-        my $version_id = get_var("VERSION"); # Should be the version number.
-        my $ver_major = substr($version_id, 0, index($version_id, q/./));
-        my $ver_minor = substr($version_id, index($version_id, q/./), length($version_id));
-        my $target = lc($ver_major);
-        if ( $ver_major == '9' || '8' ) {
-            $target = lc($version_id);
-        }
+    my $version_id = get_var("VERSION");    # Should be the version number.
+    my $ver_major = substr($version_id, 0, index($version_id, q/./));
+    my $ver_minor = substr($version_id, index($version_id, q/./), length($version_id));
+    my $target = lc($ver_major);
+    if ($ver_major == '9' || '8') {
+        $target = lc($version_id);
+    }
 
-        my $reltag = script_output 'rpm -q rocky-release --qf "%{RELEASE}\n"';
-        my $relver = substr($reltag, 0, rindex($reltag, q/./));
-        my $eltag = substr($reltag, rindex($reltag, q/./)+1, length($reltag));
+    my $reltag = script_output 'rpm -q rocky-release --qf "%{RELEASE}\n"';
+    my $relver = substr($reltag, 0, rindex($reltag, q/./));
+    my $eltag = substr($reltag, rindex($reltag, q/./) + 1, length($reltag));
 
-        my $code_name = get_code_name();
-        my $version = "$version_id ($code_name)";
-        my $platform_id = "platform:$eltag";
-        my $pretty = "$fullname $version_id ($code_name)";
+    my $code_name = get_code_name();
+    my $version = "$version_id ($code_name)";
+    my $platform_id = "platform:$eltag";
+    my $pretty = "$fullname $version_id ($code_name)";
 
-        #Now. we can start testing the real values from the installed system.
-        my @fails = ();
-        my $failref =\@fails;
+    #Now. we can start testing the real values from the installed system.
+    my @fails = ();
+    my $failref = \@fails;
 
-        # Test for name
-        my $strip = strip_marks($content{'NAME'});
-        rec_log "NAME should be $fullname and is $strip", $strip eq $fullname, $failref;
+    # Test for name
+    my $strip = strip_marks($content{'NAME'});
+    rec_log "NAME should be $fullname and is $strip", $strip eq $fullname, $failref;
 
-        # Test for version.
-        $strip = strip_marks($content{'VERSION'});
-        rec_log "VERSION should be $version and is $strip",  $strip eq $version, $failref;
+    # Test for version.
+    $strip = strip_marks($content{'VERSION'});
+    rec_log "VERSION should be $version and is $strip", $strip eq $version, $failref;
 
-        # Test for version_id
-        $strip = strip_marks($content{'VERSION_ID'});
-        rec_log "VERSION_ID should be $version_id and is $strip", $strip eq $version_id, $failref;
+    # Test for version_id
+    $strip = strip_marks($content{'VERSION_ID'});
+    rec_log "VERSION_ID should be $version_id and is $strip", $strip eq $version_id, $failref;
 
-        # Test for platform_id
-        $strip = strip_marks($content{'PLATFORM_ID'});
-        rec_log "PLATFORM_ID should be $platform_id and is $strip", $strip eq $platform_id, $failref;
+    # Test for platform_id
+    $strip = strip_marks($content{'PLATFORM_ID'});
+    rec_log "PLATFORM_ID should be $platform_id and is $strip", $strip eq $platform_id, $failref;
 
-        # Test for pretty name
-        $strip = strip_marks($content{'PRETTY_NAME'});
-        rec_log "PRETTY_NAME should be $pretty and is $strip", $strip eq $pretty, $failref;
+    # Test for pretty name
+    $strip = strip_marks($content{'PRETTY_NAME'});
+    rec_log "PRETTY_NAME should be $pretty and is $strip", $strip eq $pretty, $failref;
 
-        # Test for Rocky Support Product
-        $strip = strip_marks($content{'ROCKY_SUPPORT_PRODUCT'});
-        if ( $ver_major == '9' || '8' ) {
-            $fullname = qq/$fullname $ver_major/;
-            $fullname =~ s/ /-/g;
-        }
-        rec_log "ROCKY_SUPPORT_PRODUCT should be $fullname and is $strip", $strip eq $fullname, $failref;
+    # Test for Rocky Support Product
+    $strip = strip_marks($content{'ROCKY_SUPPORT_PRODUCT'});
+    if ($ver_major == '9' || '8') {
+        $fullname = qq/$fullname $ver_major/;
+        $fullname =~ s/ /-/g;
+    }
+    rec_log "ROCKY_SUPPORT_PRODUCT should be $fullname and is $strip", $strip eq $fullname, $failref;
 
-        # Test for Rocky Support Product Version
-        $strip = strip_marks($content{ROCKY_SUPPORT_PRODUCT_VERSION});
-        rec_log "ROCKY_SUPPORT_PRODUCT_VERSION should be $target and is $strip", $strip eq $target, $failref;
+    # Test for Rocky Support Product Version
+    $strip = strip_marks($content{ROCKY_SUPPORT_PRODUCT_VERSION});
+    rec_log "ROCKY_SUPPORT_PRODUCT_VERSION should be $target and is $strip", $strip eq $target, $failref;
 
-	# VERSION_ID should be 8.4 and is "8.4"
-	# PLATFORM_ID should be platform: and is platform:el8
-	# ROCKY_SUPPORT_PRODUCT should be Rocky and is Rocky Linux
-	# ROCKY_SUPPORT_PRODUCT_VERSION should be  and is 8 at /var/lib/openqa/share/tests/rocky/tests/os_release.pm line 95.
+    # VERSION_ID should be 8.4 and is "8.4"
+    # PLATFORM_ID should be platform: and is platform:el8
+    # ROCKY_SUPPORT_PRODUCT should be Rocky and is Rocky Linux
+    # ROCKY_SUPPORT_PRODUCT_VERSION should be  and is 8 at /var/lib/openqa/share/tests/rocky/tests/os_release.pm line 95.
 
-	# Check for fails, count them, collect their messages and die if something was found.
-        my $failcount = scalar @fails;
-        script_run "echo \"There were $failcount failures in total.\" >> /tmp/os-release.log";
-        upload_logs "/tmp/os-release.log", failok=>1;
+    # Check for fails, count them, collect their messages and die if something was found.
+    my $failcount = scalar @fails;
+    script_run "echo \"There were $failcount failures in total.\" >> /tmp/os-release.log";
+    upload_logs "/tmp/os-release.log", failok => 1;
 
-        my $failmessages = "";
-        foreach my $fail (@fails) {
-            $failmessages .= "\n".$fail;
-        }
-        die $failmessages if ($failcount > 0);
+    my $failmessages = "";
+    foreach my $fail (@fails) {
+        $failmessages .= "\n" . $fail;
+    }
+    die $failmessages if ($failcount > 0);
 }
 
 sub test_flags {

--- a/tests/podman.pm
+++ b/tests/podman.pm
@@ -8,7 +8,7 @@ use utils;
 
 sub run {
     my $self = shift;
-    $self->root_console(tty=>3);
+    $self->root_console(tty => 3);
     # on non-canned flavors, we need to install podman
     assert_script_run "dnf -y install podman", 180 unless (get_var("CANNED"));
     # check podman is installed
@@ -44,7 +44,7 @@ sub run {
 
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/preinstall_iso_in_hd.pm
+++ b/tests/preinstall_iso_in_hd.pm
@@ -8,17 +8,17 @@ sub run {
     # select rescue shell and expect shell prompt
     type_string "3\n";
     send_key "ret";
-    assert_screen "root_console", 5; # should be shell prompt
+    assert_screen "root_console", 5;    # should be shell prompt
     assert_script_run "fdisk -l | head -n20";
     assert_script_run "mkdir -p /hd";
     assert_script_run "mount /dev/vdb1 /hd";
     copy_devcdrom_as_isofile('/hd/fedora_image.iso');
     assert_script_run "umount /hd";
-    type_string "exit\n"; # leave rescue mode.
+    type_string "exit\n";    # leave rescue mode.
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/realmd_join_cockpit.pm
+++ b/tests/realmd_join_cockpit.pm
@@ -72,7 +72,7 @@ sub run {
 }
 
 sub test_flags {
-    return { fatal => 1, milestone => 1 };
+    return {fatal => 1, milestone => 1};
 }
 
 1;

--- a/tests/realmd_join_sssd.pm
+++ b/tests/realmd_join_sssd.pm
@@ -7,7 +7,7 @@ use tapnet;
 use utils;
 
 sub run {
-    my $self=shift;
+    my $self = shift;
     # use FreeIPA server or replica as DNS server
     my $server = 'ipa001.test.openqa.fedoraproject.org';
     my $server_ip = '172.16.2.100';
@@ -86,7 +86,7 @@ sub run {
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/rescue_mode_encrypted.pm
+++ b/tests/rescue_mode_encrypted.pm
@@ -7,10 +7,10 @@ sub run {
     select_rescue_mode;
     # continue
     type_string "1\n";
-    assert_screen "rescue_enter_pass", 60; # it might take time to scan all disks
+    assert_screen "rescue_enter_pass", 60;    # it might take time to scan all disks
     type_string get_var("ENCRYPT_PASSWORD", "weakpassword");
     send_key "ret";
-    assert_screen "rescue_mounted", 60; # it also might take time to mount disk
+    assert_screen "rescue_mounted", 60;    # it also might take time to mount disk
     send_key "ret";
 
     # check whether disk was mounted
@@ -24,7 +24,7 @@ sub run {
 
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/role_deploy_database_server.pm
+++ b/tests/role_deploy_database_server.pm
@@ -7,7 +7,7 @@ use tapnet;
 use utils;
 
 sub run {
-    my $self=shift;
+    my $self = shift;
     # use compose repo, disable u-t, etc.
     repo_setup();
     # deploy postgres directly ourselves. first, install packages...
@@ -54,10 +54,10 @@ sub run {
     # check we can add a row to the table
     assert_script_run 'su postgres -c "psql openqa -c \'INSERT INTO test VALUES (5);\'"';
     # check we can query the table
-    validate_script_output 'su postgres -c "psql openqa -c \'SELECT * FROM test;\'"', sub {$_ =~ m/^ *testcol.*5.*1 row/s };
+    validate_script_output 'su postgres -c "psql openqa -c \'SELECT * FROM test;\'"', sub { $_ =~ m/^ *testcol.*5.*1 row/s };
     # check we can modify the row
     assert_script_run 'su postgres -c "psql openqa -c \'UPDATE test SET testcol = 50 WHERE testcol = 5;\'"';
-    validate_script_output 'su postgres -c "psql openqa -c \'SELECT * FROM test;\'"', sub {$_ =~ m/^ *testcol.*50.*1 row/s };
+    validate_script_output 'su postgres -c "psql openqa -c \'SELECT * FROM test;\'"', sub { $_ =~ m/^ *testcol.*50.*1 row/s };
     # we're all ready for other jobs to run!
     mutex_create('db_ready');
     wait_for_children;
@@ -73,7 +73,7 @@ sub run {
 
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/role_deploy_domain_controller.pm
+++ b/tests/role_deploy_domain_controller.pm
@@ -78,7 +78,7 @@ sub run {
 
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/role_deploy_domain_controller_check.pm
+++ b/tests/role_deploy_domain_controller_check.pm
@@ -40,7 +40,7 @@ sub run {
 
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/server_cockpit_autoupdate.pm
+++ b/tests/server_cockpit_autoupdate.pm
@@ -6,7 +6,7 @@ use packagetest;
 use cockpit;
 
 sub run {
-    my $self=shift;
+    my $self = shift;
 
     # Start Cockpit
     start_cockpit(1);
@@ -40,11 +40,11 @@ sub run {
     assert_script_run "systemctl is-active dnf-automatic-install.timer";
 
     # Check that it is scheduled correctly
-    validate_script_output "systemctl show dnf-automatic-install.timer | grep TimersCalendar", sub {$_ =~ "06:00:00" };
+    validate_script_output "systemctl show dnf-automatic-install.timer | grep TimersCalendar", sub { $_ =~ "06:00:00" };
 }
 
 sub test_flags {
-    return { always_rolllback => 1 };
+    return {always_rolllback => 1};
 }
 
 1;

--- a/tests/server_cockpit_basic.pm
+++ b/tests/server_cockpit_basic.pm
@@ -5,7 +5,7 @@ use utils;
 use cockpit;
 
 sub run {
-    my $self=shift;
+    my $self = shift;
     # run firefox and login to cockpit
     start_cockpit(1);
     # go to the logs screen
@@ -26,7 +26,7 @@ sub run {
     assert_screen "cockpit_logs_detail";
     # go to the services screen
     assert_and_click "cockpit_services";
-    wait_still_screen(timeout=>90, stilltime=>5);
+    wait_still_screen(timeout => 90, stilltime => 5);
     # click on an entry
     assert_and_click "cockpit_services_entry";
     # check we get to the appropriate detail screen...but this click
@@ -36,7 +36,7 @@ sub run {
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/server_cockpit_default.pm
+++ b/tests/server_cockpit_default.pm
@@ -24,7 +24,7 @@ sub run {
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/server_cockpit_updates.pm
+++ b/tests/server_cockpit_updates.pm
@@ -6,7 +6,7 @@ use packagetest;
 use cockpit;
 
 sub run {
-    my $self=shift;
+    my $self = shift;
 
     my $cockdate = "0";
     # Remove a package, disable repositories and enable test repositories, install the package
@@ -32,37 +32,37 @@ sub run {
     # Provide a bit of extra time to match that screen
     if (check_screen('cockpit_updates_security_install', 180)) {
 
-      # There may be a large number of security updates to install
-      # so give the system more time to complete those updates.
-      assert_and_click 'cockpit_updates_security_install';
-      my $run = 0;
-      while ($run < 60) {
+        # There may be a large number of security updates to install
+        # so give the system more time to complete those updates.
+        assert_and_click 'cockpit_updates_security_install';
+        my $run = 0;
+        while ($run < 60) {
 
-        # Ignore rebooting the system because we want to finish the test instead.
-        if (check_screen('cockpit_updates_restart_ignore', 1)) {
-            assert_and_click 'cockpit_updates_restart_ignore';
-            last;
+            # Ignore rebooting the system because we want to finish the test instead.
+            if (check_screen('cockpit_updates_restart_ignore', 1)) {
+                assert_and_click 'cockpit_updates_restart_ignore';
+                last;
+            }
+            else {
+                sleep 60;
+                $run = $run + 1;
+            }
+
+            # move the mouse a bit
+            mouse_set 100, 100;
+            # also click, if we're a VNC client, seems just moving mouse
+            # isn't enough to defeat blanking
+            mouse_click if (get_var("VNC_CLIENT"));
+            mouse_hide;
         }
-        else {
-            sleep 60;
-            $run = $run + 1;
+        wait_still_screen 2;
+
+        # Rocky cockpit UI may require a scroll-down event after
+        # updating.
+        if (check_screen('cockpit_updates_security_complete', 180)) {
+            assert_screen ["cockpit_updates_security_complete"], 120;
+            click_lastmatch;
         }
-
-        # move the mouse a bit
-        mouse_set 100, 100;
-        # also click, if we're a VNC client, seems just moving mouse
-        # isn't enough to defeat blanking
-        mouse_click if (get_var("VNC_CLIENT"));
-        mouse_hide;
-      }
-      wait_still_screen 2;
-
-      # Rocky cockpit UI may require a scroll-down event after
-      # updating.
-      if (check_screen('cockpit_updates_security_complete', 180)) {
-       assert_screen ["cockpit_updates_security_complete"], 120;
-        click_lastmatch;
-      }
 
     }
 
@@ -117,7 +117,7 @@ sub run {
 }
 
 sub test_flags {
-    return { always_rollback => 1 };
+    return {always_rollback => 1};
 }
 
 1;

--- a/tests/server_filesystem_default.pm
+++ b/tests/server_filesystem_default.pm
@@ -6,14 +6,14 @@ use utils;
 sub run {
     my $self = shift;
     # switch to TTY3 for both, graphical and console tests
-    $self->root_console(tty=>3);
+    $self->root_console(tty => 3);
 
     # check / is xfs, as it should be on server
     assert_script_run 'findmnt -M / -o FSTYPE | grep xfs';
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/server_firewall_default.pm
+++ b/tests/server_firewall_default.pm
@@ -3,9 +3,9 @@ use strict;
 use testapi;
 
 sub run {
-    my $self=shift;
-    if (not( check_screen "root_console", 0)) {
-        $self->root_console(tty=>3);
+    my $self = shift;
+    if (not(check_screen "root_console", 0)) {
+        $self->root_console(tty => 3);
     }
     # this only succeeds if the firewall is running
     assert_script_run 'firewall-cmd --state';
@@ -17,7 +17,7 @@ sub run {
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/server_remote_logging_client.pm
+++ b/tests/server_remote_logging_client.pm
@@ -4,9 +4,9 @@ use testapi;
 use lockapi;
 
 sub run {
-    my $self=shift;
-    if (not (check_screen "root_console", 0)) {
-        $self->root_console(tty=>3);
+    my $self = shift;
+    if (not(check_screen "root_console", 0)) {
+        $self->root_console(tty => 3);
     }
     # ensure rsyslog is installed and enabled
     script_run "dnf -y install rsyslog", 180;
@@ -31,7 +31,7 @@ sub run {
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/server_remote_logging_server.pm
+++ b/tests/server_remote_logging_server.pm
@@ -5,9 +5,9 @@ use lockapi;
 use mmapi;
 
 sub run {
-    my $self=shift;
-    if (not (check_screen "root_console", 0)) {
-        $self->root_console(tty=>3);
+    my $self = shift;
+    if (not(check_screen "root_console", 0)) {
+        $self->root_console(tty => 3);
     }
     # ensure rsyslog is installed and enabled
     script_run "dnf -y install rsyslog", 180;
@@ -33,7 +33,7 @@ sub run {
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/text_login_gui.pm
+++ b/tests/text_login_gui.pm
@@ -7,11 +7,11 @@ sub run {
     my $self = shift;
 
     boot_to_login_screen(timeout => 300);
-    $self->root_console(tty=>3);
+    $self->root_console(tty => 3);
 }
 
 sub test_flags {
-    return { fatal => 1, milestone => 1 };
+    return {fatal => 1, milestone => 1};
 }
 1;
 # vim: set sw=4 et:

--- a/tests/uefi_postinstall.pm
+++ b/tests/uefi_postinstall.pm
@@ -4,9 +4,9 @@ use testapi;
 use utils;
 
 sub run {
-    my $self=shift;
-    if (not( check_screen "root_console", 0)) {
-        $self->root_console(tty=>4);
+    my $self = shift;
+    if (not(check_screen "root_console", 0)) {
+        $self->root_console(tty => 4);
     }
     assert_screen "root_console";
     # for aarch64 non-english tests
@@ -16,7 +16,7 @@ sub run {
 }
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/unwanted_packages.pm
+++ b/tests/unwanted_packages.pm
@@ -6,7 +6,7 @@ use utils;
 sub run {
     my $self = shift;
     # switch to TTY3 for both, graphical and console tests
-    $self->root_console(tty=>3);
+    $self->root_console(tty => 3);
     my @unwanteds;
     my $subv = get_var("SUBVARIANT");
     if ($subv eq "Workstation") {
@@ -19,7 +19,7 @@ sub run {
 
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/upgrade_boot.pm
+++ b/tests/upgrade_boot.pm
@@ -7,7 +7,7 @@ sub run {
     my $self = shift;
     # handle bootloader, if requested
     if (get_var("GRUB_POSTINSTALL")) {
-        do_bootloader(postinstall=>1, params=>get_var("GRUB_POSTINSTALL"));
+        do_bootloader(postinstall => 1, params => get_var("GRUB_POSTINSTALL"));
     }
 
     # decrypt disks during boot if necessary
@@ -17,7 +17,7 @@ sub run {
 
     boot_to_login_screen;
     # switch to TTY3 for both, graphical and console tests
-    $self->root_console(tty=>3);
+    $self->root_console(tty => 3);
     # disable screen blanking (update can take a long time)
     script_run "setterm -blank 0";
     # adjust repo files to use mirrorlist not metalink (to avoid
@@ -27,7 +27,7 @@ sub run {
 
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/upgrade_postinstall.pm
+++ b/tests/upgrade_postinstall.pm
@@ -6,13 +6,13 @@ use utils;
 sub run {
     my $self = shift;
     # try to login, check whether target release is installed
-    $self->root_console(tty=>3);
+    $self->root_console(tty => 3);
     check_release(lc(get_var('VERSION')));
 }
 
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/upgrade_preinstall.pm
+++ b/tests/upgrade_preinstall.pm
@@ -19,7 +19,7 @@ sub run {
 
     # handle bootloader, if requested
     if (get_var("GRUB_POSTINSTALL")) {
-        do_bootloader(postinstall=>1, params=>get_var("GRUB_POSTINSTALL"), timeout=>120);
+        do_bootloader(postinstall => 1, params => get_var("GRUB_POSTINSTALL"), timeout => 120);
     }
 
     # decrypt if necessary
@@ -28,7 +28,7 @@ sub run {
     }
 
     boot_to_login_screen;
-    $self->root_console(tty=>3);
+    $self->root_console(tty => 3);
 
     my $update_command = 'dnf -y install dnf-plugin-system-upgrade';
     assert_script_run $update_command, 600;
@@ -36,7 +36,7 @@ sub run {
 
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/upgrade_run.pm
+++ b/tests/upgrade_run.pm
@@ -45,7 +45,7 @@ sub run {
     # handle bootloader, if requested; set longer timeout as sometimes
     # reboot here seems to take a long time
     if (get_var("GRUB_POSTINSTALL")) {
-        do_bootloader(postinstall=>1, params=>get_var("GRUB_POSTINSTALL"), timeout=>120);
+        do_bootloader(postinstall => 1, params => get_var("GRUB_POSTINSTALL"), timeout => 120);
     }
 
     # decrypt, if encrypted
@@ -60,7 +60,7 @@ sub run {
 
 
 sub test_flags {
-    return { fatal => 1 };
+    return {fatal => 1};
 }
 
 1;

--- a/tests/workstation_core_applications.pm
+++ b/tests/workstation_core_applications.pm
@@ -7,7 +7,7 @@ use utils;
 
 sub run {
     my $self = shift;
-    $self->root_console(tty=>3);
+    $self->root_console(tty => 3);
 
     # List of applications, that we want to track for their presence.
     my @core_applications = ("gnome-software", "firefox", "gnome-terminal", "nautilus", "gedit", "gnome-boxes");
@@ -17,7 +17,7 @@ sub run {
     my $failed;
     foreach my $app (@core_applications) {
         # @utils::application_list here is the list of registered apps
-        if (grep {$_ eq $app} @utils::application_list) {
+        if (grep { $_ eq $app } @utils::application_list) {
             assert_script_run "echo '$app=passed' >> registered.log";
         }
         else {
@@ -25,7 +25,7 @@ sub run {
             $failed = 1;
         }
     }
-    upload_logs "registered.log", failok=>1;
+    upload_logs "registered.log", failok => 1;
     die "Some core applications could not be started. Check logs." if ($failed);
 }
 

--- a/tidy
+++ b/tidy
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+#
+# perltidy rules can be found in ../.perltidyrc
+#
+usage() {
+    cat << EOF
+Usage:
+ tidy [-c|--check] [-f|--force] [-o|--only-changed] [-l|--list] [path/to/file]
+
+Options:
+ -h, -?, --help       display this help
+ -c, --check          Only check for style check differences
+ -f, --force          Force check even if tidy version mismatches
+ -o --only-changed    Only tidy files with uncommitted changes in git. This can
+                      speed up execution a lot.
+-l --list             List files tidy would touch
+ path/to/file         When passing a file as argument, tidy will run perltidy
+                      wether it is added to the git tree or not
+
+perltidy rules can be found in .perltidyrc
+EOF
+    exit
+}
+
+set -eo pipefail
+dir="$(dirname "$0")"
+
+args=""
+selection='--all'
+[[ -e "$dir/perlfiles" ]] && selection=$("$dir"/perlfiles)
+opts=$(getopt -o hcfol --long help,check,force,only-changed,list -n "$0" -- "$@") || usage
+eval set -- "$opts"
+while true; do
+  case "$1" in
+    -h | --help ) usage; shift ;;
+    -c | --check ) args+=' --check-only'; shift ;;
+    -f | --force ) force=true; shift ;;
+    -o | --only-changed ) selection='--git'; shift ;;
+    -l | --list ) args+='--list'; shift ;;
+    -- ) shift; break ;;
+    * ) break ;;
+  esac
+done
+
+shift $((OPTIND - 1))
+filename=${*:-"$selection"}
+
+if ! command -v perltidy > /dev/null 2>&1; then
+    echo "No perltidy found, install it first!"
+    exit 1
+fi
+
+# go to caller directory
+cd "$dir"
+
+# just to make sure we are at the right location
+test -e tidy || exit 1
+
+# shellcheck disable=SC2086
+tidyall $args $filename


### PR DESCRIPTION
# Description

This PR provides no additional test functionality but attempts to bring this repository into agreement with [upstream Fedora repository](https://pagure.io/fedora-qa/os-autoinst-distri-fedora) in terms of Perl code quality and consistency with an ultimate goal of making direct comparisons with upstream easier and to improve our code quality.

See the [README_perltidy.md](https://github.com/tcooper/os-autoinst-distri-rocky/blob/add_perltidy_support/README_perltidy.md) file for more details and examples.

# How Has This Been Tested?

Per the provided documentation as well as the code in this PR which was run through `pre-commit` the principle of application of `perltidy` and/or `tidyall` (via `tidy`) has been tested.

Ideally all test developers will enable and use `pre-commit` on their local clones though it is possible to use `tidy` judiciously either while developing or later to fix commits from naive contributors.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules