### PR TITLE
Mirrorlist test changes for Issue #146

### DIFF
--- a/templates.fif.json
+++ b/templates.fif.json
@@ -727,7 +727,8 @@
                 "rocky-universal-x86_64-*-64bit": 20
             },
             "settings": {
-                "MIRRORLIST_GRAPHICAL": "1"
+                "MIRRORLIST_GRAPHICAL": "1",
+                "PACKAGE_SET": "server"
             }
         },
         "install_multi": {


### PR DESCRIPTION
This test originally attempted use the dvd-iso to demonstrate installation of a graphical server from the mirrorlist.  However, after mirrorlist is selected as the Installation Source the option to install "Server with GUI" (graphical-server)  disappears from the Base Environment list and only "server", "minimal" and "custom" package sets remain. This is the subject of Issue #146.

The issue is resolved for 9.1 by selecting "server" from the Base Environment list but as mentioned in #146 there is a remaining issue with resolving the mirrorlist URL for 8.7. This is potentially a problem with a returned mirror, not the test code. New attempts to download repository metadata, presumably from a different returned mirror, were eventually successful.

In conclusion, this is a fix for 9.1 but not 8.7 and Issue #146 needs to be pursued further.

This was tested using:
```
openqa-cli api -X POST isos ISO=Rocky-9.1-20221214.1-x86_64-dvd.iso ARCH=x86_64 DISTRI=rocky FLAVOR=universal VERSION=9.1 BUILD=-"$(date +%Y%m%d.%H%M%S).0"-9.1-20221214.1-universal TEST=install_mirrorlist_graphical
openqa-cli api -X POST isos ISO=Rocky-8.7-x86_64-dvd1.iso ARCH=x86_64 DISTRI=rocky FLAVOR=universal VERSION=8.7 BUILD=-"$(date +%Y%m%d.%H%M%S).0"-8.7-20221110-universal TEST=install_mirrorlist_graphical
```
Both tests should pass but sporadic failures of 8.7 at the "_check_install_source" stage are expected.
