### PR TITLE
Anaconda text install (alternate)

### DIFF
--- a/tests/_boot_to_anaconda.pm
+++ b/tests/_boot_to_anaconda.pm
@@ -104,7 +104,7 @@ sub run {
                 unless (wait_serial "Installation") { die "Text version of Anaconda has not started."; }
             }
             else {
-                if (get_var("DISTRI") eq "rocky" && (get_major_version() < 9)) {
+                if (get_var("DISTRI") eq "rocky" && (get_version_major() < 9)) {
                     # Rocky Linux 8 doesn't have network enabled at boot so we
                     # are not prompted for VNC. If that changes in future update
                     # this conditional can be removed and the else condition

--- a/tests/_boot_to_anaconda.pm
+++ b/tests/_boot_to_anaconda.pm
@@ -104,14 +104,16 @@ sub run {
                 unless (wait_serial "Installation") { die "Text version of Anaconda has not started."; }
             }
             else {
-                if (get_var("DISTRI") eq "rocky") {
-                    # Rocky doesn't have network enabled at boot so we are not prompted
-                    # for VNC...
+                if (get_var("DISTRI") eq "rocky" && (get_major_version() < 9)) {
+                    # Rocky Linux 8 doesn't have network enabled at boot so we
+                    # are not prompted for VNC. If that changes in future update
+                    # this conditional can be removed and the else condition
+                    # can be restored as the default / only option.
                     # wait for text version of Anaconda main hub
                     assert_screen "anaconda_main_hub_text", 300;
                 }
                 else {
-                    # Fedora has a use text mode menu here
+                    # Fedora and Rocky Linux 9+ have a 'Use text mode' menu here
                     assert_screen "anaconda_use_text_mode", 300;
                     type_string "2\n";
                     # wait for text version of Anaconda main hub

--- a/tests/install_text.pm
+++ b/tests/install_text.pm
@@ -105,11 +105,6 @@ sub run {
     console_type_wait("1\n");    # create new
     console_type_wait("3\n");    # set username
     console_type_wait("$username\n");
-    # from Rawhide-20190503.n.0 (F31) onwards, 'use password' is default
-    if ((get_release_number() < 31) || (get_version_major() < 9)) {
-        # typing "4\n" on abrt screen causes system to reboot, so be careful
-        run_with_error_check(sub { console_type_wait("4\n") }, $error);    # use password
-    }
     console_type_wait("5\n");    # set password
     console_type_wait("$userpwd\n");
     console_type_wait("$userpwd\n");


### PR DESCRIPTION
This PR is an alternate solution to that provided in #162 that doesn't supply a new needle but modifies the code of `_boot_to_anaconda` to properly handle the difference between Rocky Linux 8 and 9 with respect to boot with network up.

The existence of active network in Rocky Linux 9 Anaconda Installer produces a menu to select VNC or Text Install before the Network Spoke can be entered to activate the network (the Rocky Linux 8 path) in the install flow.

Additionally, this PR fixes password entry behavior for Rocky Linux 9 where `Use Password` is enabled by default (it is not enabled in Rocky Linux 8). Using non-versioned code turns off `Use Password` in the Rocky Linux 9 instance breaking the test during `install_text`.

Testing:

Test with...

```bash
$ openqa-cli api -X POST isos ISO=Rocky-9.1-20221214.1-x86_64-dvd.iso ARCH=x86_64 DISTRI=rocky FLAVOR=universal VERSION=9.1 BUILD=$(date +%Y%m%d)-Rocky-9.1-x86_64.0 TEST=install_anaconda_text
```

Where test passed both the `_boot_to_anaconda` and `install_text` testing in Rocky Linux 9.1 fully completing the installation of the system via Anaconda Text Install method.

![rocky9u1_install_text_complete](https://user-images.githubusercontent.com/542846/226231012-e8dee5bf-6eb9-4938-a3a5-8c78ef442ab2.png)

After submission and before acceptance this test should be run to completion as an `openqa-clone-custom-git-refspec` run referencing this PR for both Rocky Linux 8.7 and 9.1.

If accepted and merged this PR fixes #145.