### PR TITLE
Serial console install

### DIFF
--- a/tests/_boot_to_anaconda.pm
+++ b/tests/_boot_to_anaconda.pm
@@ -99,8 +99,11 @@ sub run {
                 # we direct the installer to virtio-console1, and use
                 # virtio-console as a root console
                 select_console('virtio-console1');
-                unless (wait_serial "Use text mode", timeout => 120) { die "Anaconda has not started."; }
-                type_string "2\n";
+                if (get_var("DISTRI") eq "rocky" && (get_version_major() > 8)) {
+                    unless (wait_serial "Use text mode", timeout => 120) { die "Anaconda has not started."; }
+                    type_string "2\n";
+                }
+                # see comment below
                 unless (wait_serial "Installation") { die "Text version of Anaconda has not started."; }
             }
             else {


### PR DESCRIPTION
Network is enabled by default at v9 so requires conditional code to handle multiple versions.
Tested for 9.1, 8.7 & 8.8:
```
openqa-cli api -X POST isos ISO=Rocky-9.1-20221214.1-x86_64-dvd.iso ARCH=x86_64 DISTRI=rocky FLAVOR=universal VERSION=9.1 BUILD=-"$(date +%Y%m%d.%H%M%S).0"-9.1-20221214.1-universal TEST=install_serial_console
openqa-cli api -X POST isos ISO=Rocky-8.7-x86_64-dvd1.iso ARCH=x86_64 DISTRI=rocky FLAVOR=universal VERSION=8.7 BUILD=-"$(date +%Y%m%d.%H%M%S).0"-8.7-20221110-universal TEST=install_serial_console
openqa-cli api -X POST isos ISO=Rocky-8.8-x86_64-dvd1.iso ARCH=x86_64 DISTRI=rocky FLAVOR=universal VERSION=8.8 BUILD=-"$(date +%Y%m%d.%H%M%S).0"-8.8-lookahead-universal TEST=install_serial_console
```
Result: Tests pass.
        Also confirm that all main hub check boxes are checked and user test created prior to start of installation.
Fixes Issue #102
