### PR TITLE
Use pandoc-common instead of python3-kickstart for package tests

### DIFF
--- a/lib/packagetest.pm
+++ b/lib/packagetest.pm
@@ -9,15 +9,15 @@ use testapi;
 our @EXPORT = qw/prepare_test_packages verify_installed_packages verify_updated_packages/;
 
 # enable the openqa test package repositories and install the main
-# test packages, remove python3-kickstart and install the fake one
+# test packages, remove pandoc-common and install the fake one
 sub prepare_test_packages {
-    # remove python3-kickstart if installed (we don't use assert
+    # remove pandoc-common if installed (we don't use assert
     # here in case it's not)
-    script_run 'dnf -y remove python3-kickstart', 180;
+    script_run 'dnf -y remove pandoc-common', 180;
     # grab the test repo definitions
     assert_script_run 'curl -o /etc/yum.repos.d/openqa-testrepo-1.repo https://fedorapeople.org/groups/qa/openqa-repos/openqa-testrepo-1.repo';
     # install the test packages from repo1
-    assert_script_run 'dnf -y --disablerepo=* --enablerepo=openqa-testrepo-1 install python3-kickstart';
+    assert_script_run 'dnf -y --disablerepo=* --enablerepo=openqa-testrepo-1 install pandoc-common';
     if (get_var("DESKTOP") eq 'kde' && get_var("TEST") eq 'desktop_update_graphical') {
         # kick pkcon so our special update will definitely get installed
         assert_script_run 'pkcon refresh force';
@@ -27,15 +27,15 @@ sub prepare_test_packages {
 # check our test packages installed correctly (this is a test that dnf
 # actually does what it claims)
 sub verify_installed_packages {
-    validate_script_output 'rpm -q python3-kickstart', sub { $_ =~ m/^python3-kickstart-1.1.noarch$/ };
-    assert_script_run 'rpm -V python3-kickstart';
+    validate_script_output 'rpm -q pandoc-common', sub { $_ =~ m/^pandoc-common-1.1.noarch$/ };
+    assert_script_run 'rpm -V pandoc-common';
 }
 
-# check updating the test packages and the fake python3-kickstart work
+# check updating the test packages and the fake pandoc-common work
 # as expected
 sub verify_updated_packages {
-    # we don't know what version of python3-kickstart we'll actually
+    # we don't know what version of pandoc-common we'll actually
     # get, so just check it's *not* the fake one
-    validate_script_output 'rpm -q python3-kickstart', sub { $_ !~ m/^python3-kickstart-1-1.noarch$/ };
-    assert_script_run 'rpm -V python3-kickstart';
+    validate_script_output 'rpm -q pandoc-common', sub { $_ !~ m/^pandoc-common-1-1.noarch$/ };
+    assert_script_run 'rpm -V pandoc-common';
 }

--- a/tests/base_update_cli.pm
+++ b/tests/base_update_cli.pm
@@ -11,16 +11,16 @@ sub run {
     prepare_test_packages;
     # check rpm agrees they installed good
     verify_installed_packages;
-    # update the fake python3-kickstart (should come from the real repo)
+    # update the fake pandoc-common (should come from the real repo)
     # this can take a long time if we get unlucky with the metadata refresh
-    assert_script_run 'dnf -y --disablerepo=openqa-testrepo* --disablerepo=updates-testing update python3-kickstart', 600;
+    assert_script_run 'dnf -y --disablerepo=openqa-testrepo* --disablerepo=updates-testing update pandoc-common', 600;
     # check we got the updated version
     verify_updated_packages;
-    # now remove python3-kickstart, and see if we can do a straight
+    # now remove pandoc-common, and see if we can do a straight
     # install from the default repos
-    assert_script_run 'dnf -y remove python3-kickstart';
-    assert_script_run 'dnf -y --disablerepo=openqa-testrepo* --disablerepo=updates-testing install python3-kickstart', 120;
-    assert_script_run 'rpm -V python3-kickstart';
+    assert_script_run 'dnf -y remove pandoc-common';
+    assert_script_run 'dnf -y --disablerepo=openqa-testrepo* --disablerepo=updates-testing install pandoc-common', 120;
+    assert_script_run 'rpm -V pandoc-common';
 }
 
 sub test_flags {

--- a/tests/base_update_cli.pm
+++ b/tests/base_update_cli.pm
@@ -11,13 +11,13 @@ sub run {
     prepare_test_packages;
     # check rpm agrees they installed good
     verify_installed_packages;
-    # update the fake pandoc-common (should come from the real repo)
-    # this can take a long time if we get unlucky with the metadata refresh
-    assert_script_run 'dnf -y --disablerepo=openqa-testrepo* --disablerepo=updates-testing update pandoc-common', 600;
     if (get_var("DISTRI") eq "rocky") {
         # pandoc-common is in PowerTools in RockyLinux
         assert_script_run 'dnf config-manager --set-enabled powertools', 60;
     }
+    # update the fake pandoc-common (should come from the real repo)
+    # this can take a long time if we get unlucky with the metadata refresh
+    assert_script_run 'dnf -y --disablerepo=openqa-testrepo* --disablerepo=updates-testing update pandoc-common', 600;
     # check we got the updated version
     verify_updated_packages;
     # now remove pandoc-common, and see if we can do a straight

--- a/tests/base_update_cli.pm
+++ b/tests/base_update_cli.pm
@@ -14,6 +14,10 @@ sub run {
     # update the fake pandoc-common (should come from the real repo)
     # this can take a long time if we get unlucky with the metadata refresh
     assert_script_run 'dnf -y --disablerepo=openqa-testrepo* --disablerepo=updates-testing update pandoc-common', 600;
+    if (get_var("DISTRI") eq "rocky") {
+        # pandoc-common is in PowerTools in RockyLinux
+        assert_script_run 'dnf config-manager --set-enabled powertools', 60;
+    }
     # check we got the updated version
     verify_updated_packages;
     # now remove pandoc-common, and see if we can do a straight


### PR DESCRIPTION
Reasoning:

1. pandoc is not in critpath so will not itself be tested
2. pandoc is widely used and actively maintained
3. package is noarch
4. package has minimal deps

Hopefully this will work for everything. For some reason, the "use python3-blivet for pykickstart tests" fails mysteriously sometimes, see e.g. https://openqa.stg.fedoraproject.org/tests/2672282