### PR TITLE
use Rocky Linux controlled openqa-testrepo-1

### DIFF
--- a/lib/packagetest.pm
+++ b/lib/packagetest.pm
@@ -15,7 +15,7 @@ sub prepare_test_packages {
     # here in case it's not)
     script_run 'dnf -y remove python3-kickstart', 180;
     # grab the test repo definitions
-    assert_script_run 'curl -o /etc/yum.repos.d/openqa-testrepo-1.repo https://fedorapeople.org/groups/qa/openqa-repos/openqa-testrepo-1.repo';
+    assert_script_run 'curl -o /etc/yum.repos.d/openqa-testrepo-1.repo https://git.resf.org/testing/openqa-testrepos/raw/branch/main/openqa-testrepo-1.repo';
     # install the test packages from repo1
     assert_script_run 'dnf -y --disablerepo=* --enablerepo=openqa-testrepo-1 install python3-kickstart';
     if (get_var("DESKTOP") eq 'kde' && get_var("TEST") eq 'desktop_update_graphical') {


### PR DESCRIPTION
# Description

This PR will change the content of `/etc/yum.repos.d/openqa-testrepo-1.repo` to point at a Rocky Linux controlled repository (`https://git.resf.org/testing/openqa-testrepos/openqa-testrepo-1`) instead of the current repository controlled by the Fedora QA team (`https://fedorapeople.org/groups/qa/openqa-repos/openqa-testrepo-1/`).

# How Has This Been Tested?

- Rocky Linux 8 VM instantiated from Vagrant box
- `/etc/yum.repos.d/openqa-testrepo-1.repo` from `https://git.resf.org/testing/openqa-testrepos` installed.
- Commands from [`packagetest.pm`](https://github.com/rocky-linux/os-autoinst-distri-rocky/blob/develop/lib/packagetest.pm) run by hand (replacing `python3-kickstart` with `pandoc-common`).
- Tested with...

```
$ /usr/bin/openqa-clone-job --within-instance https://openqa.rockylinux.org 24627 _GROUP=0 TEST+=@tcooper/os-autoinst-distri-rocky#openqa-testrepo-1-change BUILD=tcooper/os-autoinst-distri-rocky#171 CASEDIR=https://github.com/tcooper/os-autoinst-distri-rocky.git#openqa-testrepo-1-change PRODUCTDIR=os-autoinst-distri-rocky NEEDLES_DIR=rocky/needles
Cloning parents of rocky-9.1-dvd-iso-x86_64-Build20230430-Rocky-9.1-x86_64.0-base_update_cli@64bit
Cloning children of rocky-9.1-dvd-iso-x86_64-Build20230430-Rocky-9.1-x86_64.0-install_default_upload@64bit
Created job #24832: rocky-9.1-dvd-iso-x86_64-Build20230430-Rocky-9.1-x86_64.0-base_update_cli@64bit -> https://openqa.rockylinux.org/t24832
Created job #24831: rocky-9.1-dvd-iso-x86_64-Build20230430-Rocky-9.1-x86_64.0-install_default_upload@64bit -> https://openqa.rockylinux.org/t24831
```

In the screen for the `base_update_cli` test it is clear that the repository config change exists and the repository is valid...

![base_update_cli-9](https://user-images.githubusercontent.com/542846/235487776-a4a7ea5f-544a-4ad9-b5f9-16561d8183f8.png)

Test location: https://openqa.rockylinux.org/tests/24832#step/base_update_cli/7

While, utimately the test fails that is due to the it looking for the `python3-kickstart` package instead of the `pandoc-common` package that the repository now contains. Merge of this PR along with #170 should allow the test to complete fully.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules