### PR TITLE
add support to specify dnf releasever during POST

### DIFF
--- a/VARIABLES.md
+++ b/VARIABLES.md
@@ -99,7 +99,7 @@ These variables should be set when tests are scheduled (when running `isos post`
 | `KOJITASK` | A Koji task ID. If set, the modified 'update testing' flow for testing scratch builds will be used: post-install tests will be run with the packages from the update, starting from the stable release base disk images |
 | `DISTRI` | contains distribution name (should be same as in WebUI, probably `rocky`) |
 | `VERSION` | contains version of distribution |
-| `FLAVOR` | indicates what type of distribution is used. Three Pungi properties, joined with `-`: `variant`, `type`, and `format`. e.g.: `Server-dvd-iso`. Special value `universal` is used to schedule the group of tests that should be run once each per arch per compose, against the 'best' available ISO |
+| `FLAVOR` | indicates what type of distribution is used. Three Pungi properties, joined with `-`: `variant`, `type`, and `format`. e.g.: `dvd-iso`. Special value `universal` is used to schedule the group of tests that should be run once each per arch per compose, against the 'best' available ISO |
 | `ARCH` | is set to architecture that will be used (`x86_64`, `i686`) |
 | `BUILD` | contains Pungi compose_id (something like `Rocky-8.4-20210801.n.0`) |
 | `LABEL` | contains Pungi compose label, if it has one (otherwise should be unset) - e.g `RC-1.5` |
@@ -108,3 +108,5 @@ These variables should be set when tests are scheduled (when running `isos post`
 | `UP1REL` | the source release for "1-release" upgrade tests (usually but not always same as `CURRREL`) |
 | `UP2REL` | the source release for "2-release" upgrade tests (currently always same as `PREVREL`) |
 | `LOCATION` | contains Pungi base compose location (something like `https://kojipkgs.rockylinux.org/compose/branched/Rocky-8.4-20210801.n.0/compose/`) |
+| `DNF_CONTENTDIR` | the value to change `/etc/dnf/vars/contentdir` to (eg. `stg/rocky`) allowing repository reconfiguration to point at staging (usually but not always used with `DNF_RELEASEVER`) |
+| `DNF_RELEASEVER` | the value to change `/etc/dnf/vars/releasever` to (eg. `8.8-Beta`) allowing repository reconfiguration to point at a specific release (usually but not always used with `DNF_CONTENTDIR`) |

--- a/tests/_do_install_and_reboot.pm
+++ b/tests/_do_install_and_reboot.pm
@@ -141,6 +141,7 @@ sub run {
     push(@actions, 'abrt') if (get_var("ABRT", '') eq "system");
     push(@actions, 'rootpw') if (get_var("INSTALLER_NO_ROOT"));
     push(@actions, 'stagingrepos') if (get_var("DNF_CONTENTDIR"));
+    push(@actions, 'releasever') if (get_var("DNF_RELEASEVER"));
     # memcheck test doesn't need to reboot at all. Rebooting from GUI
     # for lives is unreliable. And if we're already doing something
     # else at a console, we may as well reboot from there too
@@ -201,6 +202,9 @@ sub run {
             script_run 'sed -i -e "s/^mirrorlist/#mirrorlist/g;s/^#baseurl/baseurl/g" ' . $mount . '/etc/yum.repos.d/rocky-extras.repo';
         }
         assert_script_run 'printf "stg/rocky\n" > ' . $mount . '/etc/dnf/vars/contentdir';
+    }
+    if (grep { $_ eq 'releasever' } @actions) {
+        assert_script_run 'printf "%s\n" "' . get_var("DNF_RELEASEVER") . '" > ' . $mount . '/etc/dnf/vars/releasever';
     }
     type_string "reboot\n" if (grep { $_ eq 'reboot' } @actions);
 }


### PR DESCRIPTION
# Description

This PR will add support for providing an alternate location for DNF via the `releasever` variable through modification of `/etc/dnf/vars/releasever`. This feature is activated by `POST` with `DNF_RELEASEVER=<some_value>` and will often be used in concert with the `DNF_CONTENTDIR` `POST` variable to alter the DNF repository location to point at Rocky Linux staging repositories after repository definition files have been installed.

On acceptance the PR should also close #169 without merge.

# How Has This Been Tested?

- Tested with `POST`s in openQA for 8.8-Beta for all standard flavors...

```
openqa-cli api -X POST isos ISO=Rocky-8.8-x86_64-boot.iso ARCH=x86_64 DISTRI=rocky CASEDIR=https://github.com/tcooper/os-autoinst-distri-rocky.git#dnf_releasever DNF_CONTENTDIR=stg DNF_RELEASEVER=8.8-Beta FLAVOR=boot-iso VERSION=8.8 CURRREL=8 GRUB=ip=dhcp GRUBADD=inst.repo=https://download.rockylinux.org/stg/rocky/8.8-Beta/BaseOS/x86_64/os BUILD=20230501-Rocky-8.8-Beta-x86_64.0

openqa-cli api -X POST isos ISO=Rocky-8.8-x86_64-minimal.iso ARCH=x86_64 DISTRI=rocky CASEDIR=https://github.com/tcooper/os-autoinst-distri-rocky.git#dnf_releasever DNF_CONTENTDIR=stg DNF_RELEASEVER=8.8-Beta FLAVOR=minimal-iso VERSION=8.8 CURRREL=8 GRUB=ip=dhcp GRUBADD=inst.repo=https://download.rockylinux.org/stg/rocky/8.8-Beta/BaseOS/x86_64/os BUILD=20230501-Rocky-8.8-Beta-x86_64.0

openqa-cli api -X POST isos ISO=Rocky-8.8-x86_64-dvd1.iso ARCH=x86_64 DISTRI=rocky CASEDIR=https://github.com/tcooper/os-autoinst-distri-rocky.git#dnf_releasever DNF_CONTENTDIR=stg DNF_RELEASEVER=8.8-Beta FLAVOR=package-set VERSION=8.8 CURRREL=8 GRUB=ip=dhcp GRUBADD=inst.repo=https://download.rockylinux.org/stg/rocky/8.8-Beta/BaseOS/x86_64/os BUILD=20230501-Rocky-8.8-Beta-x86_64.0

openqa-cli api -X POST isos ISO=Rocky-8.8-x86_64-dvd1.iso ARCH=x86_64 DISTRI=rocky CASEDIR=https://github.com/tcooper/os-autoinst-distri-rocky.git#dnf_releasever DNF_CONTENTDIR=stg DNF_RELEASEVER=8.8-Beta FLAVOR=dvd-iso VERSION=8.8 CURRREL=8 GRUB=ip=dhcp GRUBADD=inst.repo=https://download.rockylinux.org/stg/rocky/8.8-Beta/BaseOS/x86_64/os BUILD=20230501-Rocky-8.8-Beta-x86_64.0

openqa-cli api -X POST isos ISO=Rocky-8.8-x86_64-dvd1.iso ARCH=x86_64 DISTRI=rocky CASEDIR=https://github.com/tcooper/os-autoinst-distri-rocky.git#dnf_releasever DNF_CONTENTDIR=stg DNF_RELEASEVER=8.8-Beta FLAVOR=universal VERSION=8.8 CURRREL=8 GRUB=ip=dhcp GRUBADD=inst.repo=https://download.rockylinux.org/stg/rocky/8.8-Beta/BaseOS/x86_64/os BUILD=20230501-Rocky-8.8-Beta-x86_64.0
```

In aggregate test suite results are visible in the following build and do not deviate significantly from non Beta `POST`s...

[20230501-Rocky-8.8-Beta-x86_64.0](https://openqa.rockylinux.org/tests/overview?distri=rocky&version=8.8&build=20230501-Rocky-8.8-Beta-x86_64.0&groupid=2)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules