### PR TITLE
Improve test logic, to be sure

### DIFF
--- a/tests/_boot_to_anaconda.pm
+++ b/tests/_boot_to_anaconda.pm
@@ -99,7 +99,7 @@ sub run {
                 # we direct the installer to virtio-console1, and use
                 # virtio-console as a root console
                 select_console('virtio-console1');
-                if (get_var("DISTRI") eq "rocky" && (get_version_major() > 8)) {
+                if (get_var("DISTRI") eq "rocky" && (get_version_major() >= 9)) {
                     unless (wait_serial "Use text mode", timeout => 120) { die "Anaconda has not started."; }
                     type_string "2\n";
                 }


### PR DESCRIPTION
When job 00025799 runs on the prod system, it fails but when it is cloned locally:
```
openqa-clone-job --from https://openqa.rockylinux.org --skip-download 00025799
created job #7117: rocky-8.7-universal-x86_64-Build20230503-Rocky-8.7-x86_64.0-install_serial_console@64bit -> http://localhost/t7117
```
it passes.
This PR makes a minor improvement in the test logic to get it definitely correct and thereby put my mind at rest.