### PR TITLE
Add bootloader tags

### DIFF
--- a/needles/console/rocky-bootloader_uefi-20230803.json
+++ b/needles/console/rocky-bootloader_uefi-20230803.json
@@ -12,6 +12,7 @@
   "tags": [
     "ENV-DISTRI-rocky",
     "ENV-LANGUAGE-english",
+    "bootloader",
     "bootloader_uefi"
   ]
 }

--- a/needles/console/rocky-bootloader_uefi-20230804.json
+++ b/needles/console/rocky-bootloader_uefi-20230804.json
@@ -12,6 +12,7 @@
   "tags": [
     "ENV-DISTRI-rocky",
     "ENV-LANGUAGE-english",
+    "bootloader",
     "bootloader_uefi"
   ]
 }


### PR DESCRIPTION
This MR targets test failures:

https://openqa.rockylinux.org/tests/51492#step/rescue_mode_encrypted/7
and
https://openqa.rockylinux.org/tests/51389#step/rescue_mode_encrypted/11

Screenshots shown in #187 also apply

Tested locally using:

```
./fifloader.py -c -l templates.fif.json
openqa-cli api -X POST isos ISO=Rocky-8.8-x86_64-dvd1.iso ARCH=x86_64 DISTRI=rocky FLAVOR=universal VERSION=8.8 CURRREL=8 BUILD=-"$(date +%Y%m%d.%H%M%S).0" TEST=install_rescue_encrypted
openqa-cli api -X POST isos ISO=Rocky-9.2-x86_64-dvd.iso ARCH=x86_64 DISTRI=rocky FLAVOR=universal VERSION=9.2 CURRREL=9 BUILD=-"$(date +%Y%m%d.%H%M%S).0" TEST=install_rescue_encrypted
```

Result:
Observed successful use of needles.