### PR TITLE
Fix realmd_join_sssd

### DIFF
--- a/tests/realmd_join_sssd.pm
+++ b/tests/realmd_join_sssd.pm
@@ -82,7 +82,7 @@ sub run {
 
         # deploy as a replica
         my ($ip, $hostname) = split(/ /, get_var("POST_STATIC"));
-        my $args = "--ip-address=$ip --setup-dns --auto-forwarders --setup-ca --allow-zone-overlap -U --principal admin --admin-password $ipa_admin_password";
+        my $args = "--ip-address=$ip --setup-dns --auto-forwarders --setup-ca --allow-zone-overlap -U --principal admin --admin-password '$ipa_admin_password'";
         assert_script_run "ipa-replica-install $args", 1500;
 
         # enable and start the systemd service


### PR DESCRIPTION
This PR fixes `realmd_join_sssd` to prevent bash history expansion error during `ipa-replica-install`...

**autoinst-log.txt (test [65973](https://openqa.rockylinux.org/tests/65973/logfile?filename=autoinst-log.txt))**

```
...
[2023-09-28T19:14:04.709284Z] [debug] >>> testapi::wait_serial: (?^u:fDz7D-\d+-): ok
[2023-09-28T19:14:04.709562Z] [debug] tests/realmd_join_sssd.pm:86 called testapi::assert_script_run
[2023-09-28T19:14:04.709707Z] [debug] <<< testapi::assert_script_run(cmd="ipa-replica-install --ip-address=172.16.2.107 --setup-dns --auto-forwarders --setup-ca --allow-zone-overlap -U --principal admin --admin-password b1U3OnyX!", timeout=1500, quiet=undef, fail_message="")
[2023-09-28T19:14:04.709810Z] [debug] tests/realmd_join_sssd.pm:86 called testapi::assert_script_run
[2023-09-28T19:14:04.709908Z] [debug] <<< testapi::type_string(string="ipa-replica-install --ip-address=172.16.2.107 --setup-dns --auto-forwarders --setup-ca --allow-zone-overlap -U --principal admin --admin-password b1U3OnyX!", max_interval=250, wait_screen_change=0, wait_still_screen=0, timeout=30, similarity_level=47)
[2023-09-28T19:14:10.078893Z] [debug] tests/realmd_join_sssd.pm:86 called testapi::assert_script_run
[2023-09-28T19:14:10.079316Z] [debug] <<< testapi::type_string(string="; echo lOvIj-\$?- > /dev/ttyS0\n", max_interval=250, wait_screen_change=0, wait_still_screen=0, timeout=30, similarity_level=47)
[2023-09-28T19:14:11.203313Z] [debug] tests/realmd_join_sssd.pm:86 called testapi::assert_script_run
[2023-09-28T19:14:11.203867Z] [debug] <<< testapi::wait_serial(regexp=qr/lOvIj-\d+-/u, buffer_size=undef, quiet=undef, record_output=undef, timeout=1500, expect_not_found=0, no_regex=0)
...
```

`openqa-clone-job` command for branch ([tcooper/os-autoinst-distri-rocky](https://github.com/tcooper/os-autoinst-distri-rocky/tree/realmd_join_sssd_fix)) created with `openqa-clone-custom-git-refspec` command...

```
$ openqa-clone-custom-git-refspec --dry-run --verbose https://github.com/tcooper/os-autoinst-distri-rocky/tree/realmd_join_sssd_fix https://openqa.rockylinux.org/tests/65973
```

...where generated `openqa-clone-job` command was modified to remove `--skip-chained-deps` flag and submitted to openQA producing...

```
$ /usr/bin/openqa-clone-job --parental-inheritance --within-instance "https://openqa.rockylinux.org" "65973" _GROUP="0" TEST+="@tcooper/os-autoinst-distri-rocky#realmd_join_sssd_fix" BUILD="tcooper/os-autoinst-distri-rocky#realmd_join_sssd_fix" CASEDIR="https://github.com/tcooper/os-autoinst-distri-rocky.git#realmd_join_sssd_fix" PRODUCTDIR="os-autoinst-distri-rocky" NEEDLES_DIR="needles"
Cloning parents of rocky-9.2-dvd-iso-x86_64-Buildrocky-linux_os-autoinst-distri-rocky_develop-server_freeipa_replication_replica@rocky-linux_os-autoinst-distri-rocky_develop@64bit
Cloning children of rocky-9.2-dvd-iso-x86_64-Buildrocky-linux_os-autoinst-distri-rocky_develop-install_default_upload@rocky-linux_os-autoinst-distri-rocky_develop@64bit
Cloning parents of rocky-9.2-dvd-iso-x86_64-Buildrocky-linux_os-autoinst-distri-rocky_develop-server_freeipa_replication_master@rocky-linux_os-autoinst-distri-rocky_develop@64bit
Cloning children of rocky-9.2-dvd-iso-x86_64-Buildrocky-linux_os-autoinst-distri-rocky_develop-server_freeipa_replication_master@rocky-linux_os-autoinst-distri-rocky_develop@64bit
Cloning children of rocky-9.2-dvd-iso-x86_64-Buildrocky-linux_os-autoinst-distri-rocky_develop-server_freeipa_replication_replica@rocky-linux_os-autoinst-distri-rocky_develop@64bit
Cloning parents of rocky-9.2-dvd-iso-x86_64-Buildrocky-linux_os-autoinst-distri-rocky_develop-server_freeipa_replication_client@rocky-linux_os-autoinst-distri-rocky_develop@64bit
Created job #66232: rocky-9.2-dvd-iso-x86_64-Buildrocky-linux_os-autoinst-distri-rocky_develop-install_default_upload@rocky-linux_os-autoinst-distri-rocky_develop@64bit -> https://openqa.rockylinux.org/t66232
Created job #66233: rocky-9.2-dvd-iso-x86_64-Buildrocky-linux_os-autoinst-distri-rocky_develop-server_freeipa_replication_client@rocky-linux_os-autoinst-distri-rocky_develop@64bit -> https://openqa.rockylinux.org/t66233
Created job #66234: rocky-9.2-dvd-iso-x86_64-Buildrocky-linux_os-autoinst-distri-rocky_develop-server_freeipa_replication_master@rocky-linux_os-autoinst-distri-rocky_develop@64bit -> https://openqa.rockylinux.org/t66234
Created job #66231: rocky-9.2-dvd-iso-x86_64-Buildrocky-linux_os-autoinst-distri-rocky_develop-server_freeipa_replication_replica@rocky-linux_os-autoinst-distri-rocky_develop@64bit -> https://openqa.rockylinux.org/t66231
```

Successful passing tests triggered from this run can be found in production openQA at:

- [server_freeipa_replication_master](https://openqa.rockylinux.org/tests/66234#)
- [server_freeipa_replication_replica](https://openqa.rockylinux.org/tests/66231#)
- [server_freeipa_replication_client](https://openqa.rockylinux.org/tests/66233#)

After merge to `develop` branch the `develop` branch should be able to be merged to `main` to include freeipa tests in default runs.
