### PR TITLE
update package switched to acpica-tools

### DIFF
--- a/lib/packagetest.pm
+++ b/lib/packagetest.pm
@@ -9,15 +9,15 @@ use testapi;
 our @EXPORT = qw/prepare_test_packages verify_installed_packages verify_updated_packages/;
 
 # enable the openqa test package repositories and install the main
-# test packages, remove pandoc-common and install the fake one
+# test packages, remove acpica-tools and install the fake one
 sub prepare_test_packages {
-    # remove pandoc-common if installed (we don't use assert
+    # remove acpica-tools if installed (we don't use assert
     # here in case it's not)
-    script_run 'dnf -y remove pandoc-common', 180;
+    script_run 'dnf -y remove acpica-tools', 180;
     # grab the test repo definitions
     assert_script_run 'curl -o /etc/yum.repos.d/openqa-testrepo-1.repo https://git.resf.org/testing/openqa-testrepos/raw/branch/main/openqa-testrepo-1.repo';
     # install the test packages from repo1
-    assert_script_run 'dnf -y --disablerepo=* --enablerepo=openqa-testrepo-1 install pandoc-common';
+    assert_script_run 'dnf -y --disablerepo=* --enablerepo=openqa-testrepo-1 install acpica-tools';
     if (get_var("DESKTOP") eq 'kde' && get_var("TEST") eq 'desktop_update_graphical') {
         # kick pkcon so our special update will definitely get installed
         assert_script_run 'pkcon refresh force';
@@ -27,15 +27,15 @@ sub prepare_test_packages {
 # check our test packages installed correctly (this is a test that dnf
 # actually does what it claims)
 sub verify_installed_packages {
-    validate_script_output 'rpm -q pandoc-common', sub { $_ =~ m/^pandoc-common-1.1.noarch$/ };
-    assert_script_run 'rpm -V pandoc-common';
+    validate_script_output 'rpm -q acpica-tools', sub { $_ =~ m/^acpica-tools-1-1.noarch$/ };
+    assert_script_run 'rpm -V acpica-tools';
 }
 
-# check updating the test packages and the fake pandoc-common work
+# check updating the test packages and the fake acpica-tools work
 # as expected
 sub verify_updated_packages {
-    # we don't know what version of pandoc-common we'll actually
+    # we don't know what version of acpica-tools we'll actually
     # get, so just check it's *not* the fake one
-    validate_script_output 'rpm -q pandoc-common', sub { $_ !~ m/^pandoc-common-1-1.noarch$/ };
-    assert_script_run 'rpm -V pandoc-common';
+    validate_script_output 'rpm -q acpica-tools', sub { $_ !~ m/^acpica-tools-1-1.noarch$/ };
+    assert_script_run 'rpm -V acpica-tools';
 }

--- a/tests/base_update_cli.pm
+++ b/tests/base_update_cli.pm
@@ -15,29 +15,19 @@ sub run {
 
     # check rpm agrees they installed good
     verify_installed_packages;
-    if (get_var("DISTRI") eq "rocky") {
-        if (get_version_major() < 9) {
-            # pandoc-common is in PowerTools in Rocky Linux 8
-            assert_script_run 'dnf config-manager --set-enabled powertools', 60;
-        }
-        else {
-            # pandoc-common is in CRB in Rocky Linux 8
-            assert_script_run 'dnf config-manager --set-enabled crb', 60;
-        }
-    }
 
-    # update the fake pandoc-common (should come from the real repo)
+    # update the fake acpica-tools (should come from the real repo)
     # this can take a long time if we get unlucky with the metadata refresh
-    assert_script_run 'dnf -y --disablerepo=openqa-testrepo* --disablerepo=updates-testing update pandoc-common', 600;
+    assert_script_run 'dnf -y --disablerepo=openqa-testrepo* update acpica-tools', 600;
 
     # check we got the updated version
     verify_updated_packages;
 
-    # now remove pandoc-common, and see if we can do a straight
+    # now remove acpica-tools, and see if we can do a straight
     # install from the default repos
-    assert_script_run 'dnf -y remove pandoc-common';
-    assert_script_run 'dnf -y --disablerepo=openqa-testrepo* --disablerepo=updates-testing install pandoc-common', 120;
-    assert_script_run 'rpm -V pandoc-common';
+    assert_script_run 'dnf -y remove acpica-tools';
+    assert_script_run 'dnf -y --disablerepo=openqa-testrepo* install acpica-tools', 120;
+    assert_script_run 'rpm -V acpica-tools';
 }
 
 sub test_flags {


### PR DESCRIPTION
This PR modifies `packagetest.pm` and `base_update_cli.pm` to switch from `pandoc-common` to `acpica-tools` package for DNF update tests.

Making this change canonicalizes Rocky 8 and 9 to use the same repositories for the update package (`BaseOS`) and remove version specific logic from `base_updates_cli.pm`.

Prior to this change there was no problem running `base_update_cli` in Rocky 8 but the same test in Rocky 9 was failing due to missing `pandoc-common` package in Rocky repositories (it does exist in EPEL).

Tested in production openQA with the following commands...

### Rocky 8
```
/usr/bin/openqa-clone-job --parental-inheritance --within-instance https://openqa.rockylinux.org 91870 _GROUP=0 TEST+=@tcooper/os-autoinst-distri-rocky#updates-package-change BUILD=tcooper/os-autoinst-distri-rocky#updates-package-change CASEDIR=https://github.com/tcooper/os-autoinst-distri-rocky.git#updates-package-change PRODUCTDIR=os-autoinst-distri-rocky NEEDLES_DIR=https://github.com/tcooper/os-autoinst-distri-rocky.git#updates-package-change/needles

Cloning parents of rocky-8.9-dvd-iso-x86_64-Build20231230-Rocky-8.9-x86_64.0-base_update_cli@64bit
Cloning children of rocky-8.9-dvd-iso-x86_64-Build20231230-Rocky-8.9-x86_64.0-install_default_upload@64bit
Created job #91873: rocky-8.9-dvd-iso-x86_64-Build20231230-Rocky-8.9-x86_64.0-install_default_upload@64bit -> https://openqa.rockylinux.org/t91873
Created job #91874: rocky-8.9-dvd-iso-x86_64-Build20231230-Rocky-8.9-x86_64.0-base_update_cli@64bit -> https://openqa.rockylinux.org/t91874
```

### Rocky 9
```
/usr/bin/openqa-clone-job --parental-inheritance --within-instance https://openqa.rockylinux.org 91637 _GROUP=0 TEST+=@tcooper/os-autoinst-distri-rocky#updates-package-change BUILD=tcooper/os-autoinst-distri-rocky#updates-package-change CASEDIR=https://github.com/tcooper/os-autoinst-distri-rocky.git#updates-package-change PRODUCTDIR=os-autoinst-distri-rocky NEEDLES_DIR=https://github.com/tcooper/os-autoinst-distri-rocky.git#updates-package-change/needles

Cloning parents of rocky-9.3-dvd-iso-x86_64-Build20231230-Rocky-9.3-x86_64.0-base_update_cli@64bit
Cloning children of rocky-9.3-dvd-iso-x86_64-Build20231230-Rocky-9.3-x86_64.0-install_default_upload@64bit
Created job #91872: rocky-9.3-dvd-iso-x86_64-Build20231230-Rocky-9.3-x86_64.0-base_update_cli@64bit -> https://openqa.rockylinux.org/t91872
Created job #91871: rocky-9.3-dvd-iso-x86_64-Build20231230-Rocky-9.3-x86_64.0-install_default_upload@64bit -> https://openqa.rockylinux.org/t91871
```

Successful passing tests triggered from this run can be found in production openQA at:

- [base_update_cli@tcooper/os-autoinst-distri-rocky#updates-package-change@64bit](https://openqa.rockylinux.org/tests/91874#step/base_update_cli/16)
- [base_update_cli@tcooper/os-autoinst-distri-rocky#updates-package-change@64bit](https://openqa.rockylinux.org/tests/91872#step/base_update_cli/16)

With these changes merged to `develop` branch further updates to `server_cockpit_updates` can be completed to allow completion of `server_cockpit_*` related tests.