### PR TITLE
fix templates.fif for s390x

### DIFF
--- a/fifloader.py
+++ b/fifloader.py
@@ -212,6 +212,11 @@ def generate_job_templates(products, profiles, testsuites):
                     jobtemplate['group_name'] = "Rocky PowerPC Updates"
                 else:
                     jobtemplate['group_name'] = "Rocky PowerPC"
+            elif jobtemplate['machine_name'] in ('s390x'):
+                if 'updates' in product['flavor']:
+                    jobtemplate['group_name'] = "Rocky s390x Updates"
+                else:
+                    jobtemplate['group_name'] = "Rocky s390x"
             elif jobtemplate['machine_name'] in ('aarch64', 'ARM'):
                 if 'updates' in product['flavor']:
                     jobtemplate['group_name'] = "Rocky AArch64 Updates"

--- a/templates.fif.json
+++ b/templates.fif.json
@@ -348,7 +348,7 @@
         },
         "rocky-boot-iso-s390x-*-s390x": {
             "machine": "s390x",
-            "product": "rocky-boot-iso-ppc64le-*"
+            "product": "rocky-boot-iso-s390x-*"
         },
         "rocky-boot-iso-ppc64le-*-ppc64le": {
             "machine": "ppc64le",
@@ -368,7 +368,7 @@
         },
         "rocky-minimal-iso-s390x-*-s390x": {
             "machine": "s390x",
-            "product": "rocky-minimal-iso-ppc64le-*"
+            "product": "rocky-minimal-iso-s390x-*"
         },
         "rocky-minimal-iso-ppc64le-*-ppc64le": {
             "machine": "ppc64le",
@@ -384,7 +384,7 @@
         },
         "rocky-dvd-iso-s390x-*-s390x": {
             "machine": "s390x",
-            "product": "rocky-dvd-iso-ppc64le-*"
+            "product": "rocky-dvd-iso-s390x-*"
         },
         "rocky-dvd-iso-ppc64le-*-ppc64le": {
             "machine": "ppc64le",
@@ -404,7 +404,7 @@
         },
         "rocky-package-set-s390x-*-s390x": {
             "machine": "s390x",
-            "product": "rocky-package-set-ppc64le-*"
+            "product": "rocky-package-set-s390x-*"
         },
         "rocky-package-set-ppc64le-*-ppc64le": {
             "machine": "ppc64le",
@@ -424,7 +424,7 @@
         },
         "rocky-universal-s390x-*-s390x": {
             "machine": "s390x",
-            "product": "rocky-universal-ppc64le-*"
+            "product": "rocky-universal-s390x-*"
         },
         "rocky-universal-ppc64le-*-ppc64le": {
             "machine": "ppc64le",


### PR DESCRIPTION
An update to `fifloader.py` is required to properly parse the entries for the `s390x` machine type.

Additionally, when adding `s390x` Job Group to `templates.fif.json` (which was done by copy-paste edit of `ppc64le` entries) the product wasn't correctly updated.

Together this ommission and error resulted in the the Job Group for `s390x` not getting created with correct entries when `fifloader.py` was run in the production openQA system.

These changes were validated in a DEV instance with `./fifloader.py` as shown below (excerpted output)...

```
[geekotest@openqa-dev rocky]$ ./fifloader.py --clean --load templates.fif.json templates-updates.fif.json
/usr/lib/python3.11/site-packages/jsonschema/_validators.py:230: FutureWarning: Possible nested set at position 7
  and not re.search(patrn, instance)
Input template data is valid
Generated template data is valid
{
  JobTemplates => [
                    {
                      arch => "s390x",
                      distri => "rocky",
                      flavor => "dvd-iso",
                      group_name => "Rocky s390x",
                      machine_name => "s390x",
                      prio => 20,
                      test_suite_name => "anaconda_help",
                      version => "*",
                    },
...<snip>...
                    {
                      arch     => "s390x",
                      distri   => "rocky",
                      flavor   => "universal",
                      name     => "rocky-universal-s390x-*",
                      settings => [
                                    { key => "HDDSIZEGB", value => 15 },
                                    { key => "TEST_TARGET", value => "ISO" },
                                  ],
                      version  => "*",
                    },
...<snip>...
                    {
                      arch     => "s390x",
                      distri   => "rocky",
                      flavor   => "dvd-iso",
                      name     => "rocky-dvd-iso-s390x-*",
                      settings => [
                                    { key => "DEPLOY_UPLOAD_TEST", value => "install_default_upload" },
                                    { key => "HDDSIZEGB", value => 15 },
                                    { key => "TEST_TARGET", value => "ISO" },
                                  ],
                      version  => "*",
                    },
...<snip>...
                    {
                      backend => "qemu",
                      name => "s390x",
                      settings => [
                        { key => "ARCH_BASE_MACHINE", value => "s390x" },
                        { key => "PART_TABLE_TYPE", value => "mbr" },
                        { key => "QEMU", value => "s390x" },
                        {
                          key => "QEMU_APPEND",
                          value => "bios /usr/share/qemu/390-ccw.img -boot once=cd0",
                        },
                        { key => "QEMUMACHINE", value => "s390-ccw-virtio" },
                        { key => "QEMURAM", value => 4096 },
                        { key => "QEMU_VIDEO_DEVICE", value => "virtio-gpu" },
                        { key => "QEMU_MAX_MIGRATION_TIME", value => 480 },
                        { key => "QEMU_NO_KVM", value => 1 },
                        { key => "WORKER_CLASS", value => "qemu_s390x" },
                      ],
                    },
...<snip>...
{
  JobTemplates => { added => 357, of => 357 },
  Machines     => { added => 5, of => 5 },
  Products     => { added => 32, of => 32 },
  TestSuites   => { added => 83, of => 83 },
}
```

Views of JobGroups and s390x JobGroup detail from openqa-dev system are shown below...

![openqa-dev-jobgroups](https://github.com/rocky-linux/os-autoinst-distri-rocky/assets/542846/c8b0af5f-ba7b-4097-861e-f3b0b10a0e55)

![openqa-dev-s390x-jobgroup](https://github.com/rocky-linux/os-autoinst-distri-rocky/assets/542846/0b25c26c-f779-445e-8e19-a3e771a4bd35)




