### PR TITLE
Indication of secure boot state.

### DIFF
--- a/tests/uefi_postinstall.pm
+++ b/tests/uefi_postinstall.pm
@@ -13,6 +13,8 @@ sub run {
     console_loadkeys_us;
     # this test shows if the system is booted with efi
     assert_script_run '[ -d /sys/firmware/efi/ ]';
+    # this test shows if the system is secure boot
+    script_run 'mokutil --sb-state';
 }
 
 sub test_flags {


### PR DESCRIPTION
At present there is no indication given in our tests whether a system is secure boot enabled or not. This merge request adds non-failing code to display in the openqa test results, the secure boot status of the running system.

Tested:
```
openqa-cli api -X POST isos ISO=Rocky-8.10-x86_64-dvd1.iso ARCH=x86_64 DISTRI=rocky FLAVOR=universal VERSION=8.10 CURRREL=8 DNF_CONTENTDIR=stg/rocky DNF_RELEASEVER=8-LookAhead BUILD=-"$(date +%Y%m%d.%H%M%S).0"-universal-8.10-LookAhead TEST=install_xfs
```
Result: Pass
![Screenshot 2024-03-21 at 16-21-43 openQA rocky-8 10-universal-x86_64-Build-20240321 160347 0-universal-8 10-LookAhead-install_xfs@uefi test results](https://github.com/rocky-linux/os-autoinst-distri-rocky/assets/3416699/737078c1-d7a8-482d-a325-e4abf758cb53)
