### PR TITLE
Add network install to comply with QA:Testcase Minimal Installation

### DIFF
--- a/templates.fif.json
+++ b/templates.fif.json
@@ -787,6 +787,11 @@
         },
         "install_minimal": {
             "profiles": {
+                "rocky-boot-iso-s390x-*-s390x": 10,
+                "rocky-boot-iso-ppc64le-*-ppc64le": 10,
+                "rocky-boot-iso-aarch64-*-aarch64": 10,
+                "rocky-boot-iso-x86_64-*-64bit": 10,
+                "rocky-boot-iso-x86_64-*-uefi": 11,
                 "rocky-minimal-iso-s390x-*-s390x": 10,
                 "rocky-minimal-iso-ppc64le-*-ppc64le": 10,
                 "rocky-minimal-iso-aarch64-*-aarch64": 10,


### PR DESCRIPTION
The existing ```install_minimal@64bit``` openqa test installs from  ```Rocky-9.4-x86_64-minimal.iso``` using local media. 
```QA:Testcase Minimal Installation``` requires the install to be done from the network. hence this change.