### PR TITLE
Enable secure boot in machine type uefi

### DIFF
--- a/templates-updates.fif.json
+++ b/templates-updates.fif.json
@@ -84,40 +84,40 @@
             "machine": "aarch64",
             "product": "rocky-updates-server-upgrade-aarch64-*"
         },
-        "rocky-updates-server-upgrade-x86_64-*-64bit": {
-            "machine": "64bit",
+        "rocky-updates-server-upgrade-x86_64-*-bios": {
+            "machine": "bios",
             "product": "rocky-updates-server-upgrade-x86_64-*"
         },
         "rocky-updates-server-aarch64-*-aarch64": {
             "machine": "aarch64",
             "product": "rocky-updates-server-aarch64-*"
         },
-        "rocky-updates-server-x86_64-*-64bit": {
-            "machine": "64bit",
+        "rocky-updates-server-x86_64-*-bios": {
+            "machine": "bios",
             "product": "rocky-updates-server-x86_64-*"
         },
         "rocky-updates-workstation-upgrade-aarch64-*-aarch64": {
             "machine": "aarch64",
             "product": "rocky-updates-workstation-upgrade-aarch64-*"
         },
-        "rocky-updates-workstation-upgrade-x86_64-*-64bit": {
-            "machine": "64bit",
+        "rocky-updates-workstation-upgrade-x86_64-*-bios": {
+            "machine": "bios",
             "product": "rocky-updates-workstation-upgrade-x86_64-*"
         },
         "rocky-updates-workstation-aarch64-*-aarch64": {
             "machine": "aarch64",
             "product": "rocky-updates-workstation-aarch64-*"
         },
-        "rocky-updates-workstation-x86_64-*-64bit": {
-            "machine": "64bit",
+        "rocky-updates-workstation-x86_64-*-bios": {
+            "machine": "bios",
             "product": "rocky-updates-workstation-x86_64-*"
         },
         "rocky-updates-minimal-aarch64-*-aarch64": {
             "machine": "aarch64",
             "product": "rocky-updates-minimal-aarch64-*"
         },
-        "rocky-updates-minimal-x86_64-*-64bit": {
-            "machine": "64bit",
+        "rocky-updates-minimal-x86_64-*-bios": {
+            "machine": "bios",
             "product": "rocky-updates-minimal-x86_64-*"
         }
     },
@@ -125,7 +125,7 @@
         "advisory_boot": {
             "profiles": {
                 "rocky-updates-server-aarch64-*-aarch64": 40,
-                "rocky-updates-server-x86_64-*-64bit": 40
+                "rocky-updates-server-x86_64-*-bios": 40
             },
             "settings": {
                 "ADVISORY_BOOT_TEST": "1",
@@ -136,116 +136,116 @@
         },
         "base_selinux": {
             "profiles": {
-                "rocky-updates-minimal-x86_64-*-64bit": 40,
+                "rocky-updates-minimal-x86_64-*-bios": 40,
                 "rocky-updates-server-aarch64-*-aarch64": 40,
-                "rocky-updates-server-x86_64-*-64bit": 40,
-                "rocky-updates-workstation-x86_64-*-64bit": 40
+                "rocky-updates-server-x86_64-*-bios": 40,
+                "rocky-updates-workstation-x86_64-*-bios": 40
             }
         },
         "base_service_manipulation": {
             "profiles": {
-                "rocky-updates-minimal-x86_64-*-64bit": 40,
+                "rocky-updates-minimal-x86_64-*-bios": 40,
                 "rocky-updates-server-aarch64-*-aarch64": 40,
-                "rocky-updates-server-x86_64-*-64bit": 40,
-                "rocky-updates-workstation-x86_64-*-64bit": 40
+                "rocky-updates-server-x86_64-*-bios": 40,
+                "rocky-updates-workstation-x86_64-*-bios": 40
             }
         },
         "base_services_start": {
             "profiles": {
-                "rocky-updates-minimal-x86_64-*-64bit": 40,
+                "rocky-updates-minimal-x86_64-*-bios": 40,
                 "rocky-updates-server-aarch64-*-aarch64": 40,
-                "rocky-updates-server-x86_64-*-64bit": 40,
-                "rocky-updates-workstation-x86_64-*-64bit": 40
+                "rocky-updates-server-x86_64-*-bios": 40,
+                "rocky-updates-workstation-x86_64-*-bios": 40
             }
         },
         "base_update_cli": {
             "profiles": {
-                "rocky-updates-minimal-x86_64-*-64bit": 40,
+                "rocky-updates-minimal-x86_64-*-bios": 40,
                 "rocky-updates-server-aarch64-*-aarch64": 40,
-                "rocky-updates-server-x86_64-*-64bit": 40,
-                "rocky-updates-workstation-x86_64-*-64bit": 40
+                "rocky-updates-server-x86_64-*-bios": 40,
+                "rocky-updates-workstation-x86_64-*-bios": 40
             }
         },
         "base_reboot_unmount": {
             "profiles": {
-                "rocky-updates-minimal-x86_64-*-64bit": 40,
+                "rocky-updates-minimal-x86_64-*-bios": 40,
                 "rocky-updates-server-aarch64-*-aarch64": 40,
-                "rocky-updates-server-x86_64-*-64bit": 40,
-                "rocky-updates-workstation-x86_64-*-64bit": 40
+                "rocky-updates-server-x86_64-*-bios": 40,
+                "rocky-updates-workstation-x86_64-*-bios": 40
             }
         },
         "base_system_logging": {
             "profiles": {
-                "rocky-updates-minimal-x86_64-*-64bit": 40,
+                "rocky-updates-minimal-x86_64-*-bios": 40,
                 "rocky-updates-server-aarch64-*-aarch64": 40,
-                "rocky-updates-server-x86_64-*-64bit": 40,
-                "rocky-updates-workstation-x86_64-*-64bit": 40
+                "rocky-updates-server-x86_64-*-bios": 40,
+                "rocky-updates-workstation-x86_64-*-bios": 40
             }
         },
         "desktop_background": {
             "profiles": {
                 "rocky-updates-workstation-aarch64-*-aarch64": 30,
-                "rocky-updates-workstation-x86_64-*-64bit": 30
+                "rocky-updates-workstation-x86_64-*-bios": 30
             }
         },
         "desktop_browser": {
             "profiles": {
                 "rocky-updates-workstation-aarch64-*-aarch64": 30,
-                "rocky-updates-workstation-x86_64-*-64bit": 30
+                "rocky-updates-workstation-x86_64-*-bios": 30
             }
         },
         "desktop_printing": {
             "profiles": {
                 "rocky-updates-workstation-aarch64-*-aarch64": 30,
-                "rocky-updates-workstation-x86_64-*-64bit": 30
+                "rocky-updates-workstation-x86_64-*-bios": 30
             }
         },
         "desktop_terminal": {
             "profiles": {
                 "rocky-updates-workstation-aarch64-*-aarch64": 30,
-                "rocky-updates-workstation-x86_64-*-64bit": 30
+                "rocky-updates-workstation-x86_64-*-bios": 30
             }
         },
         "desktop_update_graphical": {
             "profiles": {
                 "rocky-updates-workstation-aarch64-*-aarch64": 30,
-                "rocky-updates-workstation-x86_64-*-64bit": 30
+                "rocky-updates-workstation-x86_64-*-bios": 30
             }
         },
         "server_cockpit_basic": {
             "profiles": {
                 "rocky-updates-server-aarch64-*-aarch64": 40,
-                "rocky-updates-server-x86_64-*-64bit": 40
+                "rocky-updates-server-x86_64-*-bios": 40
             }
         },
         "server_cockpit_default": {
             "profiles": {
                 "rocky-updates-server-aarch64-*-aarch64": 40,
-                "rocky-updates-server-x86_64-*-64bit": 40
+                "rocky-updates-server-x86_64-*-bios": 40
             }
         },
         "server_cockpit_updates": {
             "profiles": {
                 "rocky-updates-server-aarch64-*-aarch64": 40,
-                "rocky-updates-server-x86_64-*-64bit": 40
+                "rocky-updates-server-x86_64-*-bios": 40
             }
         },
         "server_database_client": {
             "profiles": {
                 "rocky-updates-server-aarch64-*-aarch64": 40,
-                "rocky-updates-server-x86_64-*-64bit": 40
+                "rocky-updates-server-x86_64-*-bios": 40
             }
         },
         "server_firewall_default": {
             "profiles": {
                 "rocky-updates-server-aarch64-*-aarch64": 40,
-                "rocky-updates-server-x86_64-*-64bit": 40
+                "rocky-updates-server-x86_64-*-bios": 40
             }
         },
         "upgrade_desktop_encrypted_64bit": {
             "profiles": {
                 "rocky-updates-workstation-upgrade-aarch64-*-aarch64": 40,
-                "rocky-updates-workstation-upgrade-x86_64-*-64bit": 40
+                "rocky-updates-workstation-upgrade-x86_64-*-bios": 40
             }
         }
     }

--- a/templates.fif.json
+++ b/templates.fif.json
@@ -66,7 +66,7 @@
                 "WORKER_CLASS": "qemu_ppc64le"
             }
         },
-        "uefi": {
+        "uefx": {
             "backend": "qemu",
             "settings": {
                 "ARCH_BASE_MACHINE": "64bit",
@@ -84,7 +84,7 @@
                 "WORKER_CLASS": "qemu_x86_64"
             }
         },
-        "uesb": {
+        "uefi": {
             "backend": "qemu",
             "settings": {
                 "ARCH_BASE_MACHINE": "64bit",

--- a/templates.fif.json
+++ b/templates.fif.json
@@ -842,6 +842,7 @@
                 "rocky-dvd-iso-s390x-*-s390x": 10,
                 "rocky-dvd-iso-ppc64le-*-ppc64le": 10,
                 "rocky-dvd-iso-aarch64-*-aarch64": 10,
+                "rocky-dvd-iso-x86_64-*-uefi": 10,
                 "rocky-dvd-iso-x86_64-*-bios": 10
             },
             "settings": {
@@ -1471,6 +1472,19 @@
                 "ENTRYPOINT": "text_login_gui rocky_release os_release",
                 "HDD_1": "disk_%FLAVOR%_%MACHINE%.qcow2",
                 "START_AFTER_TEST": "%DEPLOY_UPLOAD_TEST%",
+                "USER_LOGIN": "false"
+            }
+        },
+        "secure_boot_fallback": {
+            "profiles": {
+                "rocky-dvd-iso-x86_64-*-uefi": 11
+            },
+            "settings": {
+                "BOOTFROM": "c",
+                "HDD_1": "disk_%FLAVOR%_%MACHINE%.qcow2",
+                "POSTINSTALL": "_secure_boot_fallback",
+                "ROOT_PASSWORD": "weakpassword",
+                "+START_AFTER_TEST": "%DEPLOY_UPLOAD_TEST%",
                 "USER_LOGIN": "false"
             }
         },

--- a/templates.fif.json
+++ b/templates.fif.json
@@ -419,7 +419,7 @@
             "product": "rocky-package-set-x86_64-*"
         },
         "rocky-package-set-x86_64-*-uefi": {
-            "machine": "bios",
+            "machine": "uefi",
             "product": "rocky-package-set-x86_64-*"
         },
         "rocky-universal-s390x-*-s390x": {

--- a/templates.fif.json
+++ b/templates.fif.json
@@ -1,6 +1,6 @@
 {
     "Machines": {
-        "64bit": {
+        "bios": {
             "backend": "qemu",
             "settings": {
                 "ARCH_BASE_MACHINE": "64bit",
@@ -330,12 +330,12 @@
         }
     },
     "Profiles": {
-        "rocky-GenericCloud_Base-qcow2-qcow2-x86_64-*-64bit": {
-            "machine": "64bit",
+        "rocky-GenericCloud_Base-qcow2-qcow2-x86_64-*-bios": {
+            "machine": "bios",
             "product": "rocky-GenericCloud_Base-qcow2-qcow2-x86_64-*"
         },
-        "rocky-GenericCloud_LVM-qcow2-qcow2-x86_64-*-64bit": {
-            "machine": "64bit",
+        "rocky-GenericCloud_LVM-qcow2-qcow2-x86_64-*-bios": {
+            "machine": "bios",
             "product": "rocky-GenericCloud_LVM-qcow2-qcow2-x86_64-*"
         },
         "rocky-GenericCloud_Base-qcow2-qcow2-x86_64-*-uefi": {
@@ -358,8 +358,8 @@
             "machine": "aarch64",
             "product": "rocky-boot-iso-aarch64-*"
         },
-        "rocky-boot-iso-x86_64-*-64bit": {
-            "machine": "64bit",
+        "rocky-boot-iso-x86_64-*-bios": {
+            "machine": "bios",
             "product": "rocky-boot-iso-x86_64-*"
         },
         "rocky-boot-iso-x86_64-*-uefi": {
@@ -378,8 +378,8 @@
             "machine": "aarch64",
             "product": "rocky-minimal-iso-aarch64-*"
         },
-        "rocky-minimal-iso-x86_64-*-64bit": {
-            "machine": "64bit",
+        "rocky-minimal-iso-x86_64-*-bios": {
+            "machine": "bios",
             "product": "rocky-minimal-iso-x86_64-*"
         },
         "rocky-dvd-iso-s390x-*-s390x": {
@@ -394,8 +394,8 @@
             "machine": "aarch64",
             "product": "rocky-dvd-iso-aarch64-*"
         },
-        "rocky-dvd-iso-x86_64-*-64bit": {
-            "machine": "64bit",
+        "rocky-dvd-iso-x86_64-*-bios": {
+            "machine": "bios",
             "product": "rocky-dvd-iso-x86_64-*"
         },
         "rocky-dvd-iso-x86_64-*-uefi": {
@@ -414,12 +414,12 @@
             "machine": "aarch64",
             "product": "rocky-package-set-aarch64-*"
         },
-        "rocky-package-set-x86_64-*-64bit": {
-            "machine": "64bit",
+        "rocky-package-set-x86_64-*-bios": {
+            "machine": "bios",
             "product": "rocky-package-set-x86_64-*"
         },
         "rocky-package-set-x86_64-*-uefi": {
-            "machine": "64bit",
+            "machine": "bios",
             "product": "rocky-package-set-x86_64-*"
         },
         "rocky-universal-s390x-*-s390x": {
@@ -434,8 +434,8 @@
             "machine": "aarch64",
             "product": "rocky-universal-aarch64-*"
         },
-        "rocky-universal-x86_64-*-64bit": {
-            "machine": "64bit",
+        "rocky-universal-x86_64-*-bios": {
+            "machine": "bios",
             "product": "rocky-universal-x86_64-*"
         },
         "rocky-universal-x86_64-*-uefi": {
@@ -449,7 +449,7 @@
                 "rocky-dvd-iso-s390x-*-s390x": 20,
                 "rocky-dvd-iso-ppc64le-*-ppc64le": 20,
                 "rocky-dvd-iso-aarch64-*-aarch64": 20,
-                "rocky-dvd-iso-x86_64-*-64bit": 20
+                "rocky-dvd-iso-x86_64-*-bios": 20
             },
             "settings": {
                 "ENTRYPOINT": "_boot_to_anaconda anaconda_help",
@@ -458,14 +458,14 @@
         },
         "base_reboot_unmount": {
             "profiles": {
-                "rocky-GenericCloud_Base-qcow2-qcow2-x86_64-*-64bit": 30,
+                "rocky-GenericCloud_Base-qcow2-qcow2-x86_64-*-bios": 30,
                 "rocky-GenericCloud_Base-qcow2-qcow2-x86_64-*-uefi": 30,
-                "rocky-GenericCloud_LVM-qcow2-qcow2-x86_64-*-64bit": 30,
+                "rocky-GenericCloud_LVM-qcow2-qcow2-x86_64-*-bios": 30,
                 "rocky-GenericCloud_LVM-qcow2-qcow2-x86_64-*-uefi": 30,
                 "rocky-dvd-iso-s390x-*-s390x": 20,
                 "rocky-dvd-iso-ppc64le-*-ppc64le": 20,
                 "rocky-dvd-iso-aarch64-*-aarch64": 20,
-                "rocky-dvd-iso-x86_64-*-64bit": 20
+                "rocky-dvd-iso-x86_64-*-bios": 20
             },
             "settings": {
                 "BOOTFROM": "c",
@@ -479,14 +479,14 @@
         },
         "base_system_logging": {
             "profiles": {
-                "rocky-GenericCloud_Base-qcow2-qcow2-x86_64-*-64bit": 30,
+                "rocky-GenericCloud_Base-qcow2-qcow2-x86_64-*-bios": 30,
                 "rocky-GenericCloud_Base-qcow2-qcow2-x86_64-*-uefi": 30,
-                "rocky-GenericCloud_LVM-qcow2-qcow2-x86_64-*-64bit": 30,
+                "rocky-GenericCloud_LVM-qcow2-qcow2-x86_64-*-bios": 30,
                 "rocky-GenericCloud_LVM-qcow2-qcow2-x86_64-*-uefi": 30,
                 "rocky-dvd-iso-s390x-*-s390x": 20,
                 "rocky-dvd-iso-ppc64le-*-ppc64le": 20,
                 "rocky-dvd-iso-aarch64-*-aarch64": 20,
-                "rocky-dvd-iso-x86_64-*-64bit": 20
+                "rocky-dvd-iso-x86_64-*-bios": 20
             },
             "settings": {
                 "BOOTFROM": "c",
@@ -500,14 +500,14 @@
         },
         "base_update_cli": {
             "profiles": {
-                "rocky-GenericCloud_Base-qcow2-qcow2-x86_64-*-64bit": 30,
+                "rocky-GenericCloud_Base-qcow2-qcow2-x86_64-*-bios": 30,
                 "rocky-GenericCloud_Base-qcow2-qcow2-x86_64-*-uefi": 30,
-                "rocky-GenericCloud_LVM-qcow2-qcow2-x86_64-*-64bit": 30,
+                "rocky-GenericCloud_LVM-qcow2-qcow2-x86_64-*-bios": 30,
                 "rocky-GenericCloud_LVM-qcow2-qcow2-x86_64-*-uefi": 30,
                 "rocky-dvd-iso-s390x-*-s390x": 20,
                 "rocky-dvd-iso-ppc64le-*-ppc64le": 20,
                 "rocky-dvd-iso-aarch64-*-aarch64": 20,
-                "rocky-dvd-iso-x86_64-*-64bit": 20
+                "rocky-dvd-iso-x86_64-*-bios": 20
             },
             "settings": {
                 "BOOTFROM": "c",
@@ -521,14 +521,14 @@
         },
         "base_package_install_remove": {
             "profiles": {
-                "rocky-GenericCloud_Base-qcow2-qcow2-x86_64-*-64bit": 30,
+                "rocky-GenericCloud_Base-qcow2-qcow2-x86_64-*-bios": 30,
                 "rocky-GenericCloud_Base-qcow2-qcow2-x86_64-*-uefi": 30,
-                "rocky-GenericCloud_LVM-qcow2-qcow2-x86_64-*-64bit": 30,
+                "rocky-GenericCloud_LVM-qcow2-qcow2-x86_64-*-bios": 30,
                 "rocky-GenericCloud_LVM-qcow2-qcow2-x86_64-*-uefi": 30,
                 "rocky-dvd-iso-s390x-*-s390x": 40,
                 "rocky-dvd-iso-ppc64le-*-ppc64le": 40,
                 "rocky-dvd-iso-aarch64-*-aarch64": 40,
-                "rocky-dvd-iso-x86_64-*-64bit": 40
+                "rocky-dvd-iso-x86_64-*-bios": 40
             },
             "settings": {
                 "BOOTFROM": "c",
@@ -542,14 +542,14 @@
         },
         "base_services_start": {
             "profiles": {
-                "rocky-GenericCloud_Base-qcow2-qcow2-x86_64-*-64bit": 30,
+                "rocky-GenericCloud_Base-qcow2-qcow2-x86_64-*-bios": 30,
                 "rocky-GenericCloud_Base-qcow2-qcow2-x86_64-*-uefi": 30,
-                "rocky-GenericCloud_LVM-qcow2-qcow2-x86_64-*-64bit": 30,
+                "rocky-GenericCloud_LVM-qcow2-qcow2-x86_64-*-bios": 30,
                 "rocky-GenericCloud_LVM-qcow2-qcow2-x86_64-*-uefi": 30,
                 "rocky-dvd-iso-s390x-*-s390x": 40,
                 "rocky-dvd-iso-ppc64le-*-ppc64le": 40,
                 "rocky-dvd-iso-aarch64-*-aarch64": 40,
-                "rocky-dvd-iso-x86_64-*-64bit": 40
+                "rocky-dvd-iso-x86_64-*-bios": 40
             },
             "settings": {
                 "BOOTFROM": "c",
@@ -563,14 +563,14 @@
         },
         "base_selinux": {
             "profiles": {
-                "rocky-GenericCloud_Base-qcow2-qcow2-x86_64-*-64bit": 30,
+                "rocky-GenericCloud_Base-qcow2-qcow2-x86_64-*-bios": 30,
                 "rocky-GenericCloud_Base-qcow2-qcow2-x86_64-*-uefi": 30,
-                "rocky-GenericCloud_LVM-qcow2-qcow2-x86_64-*-64bit": 30,
+                "rocky-GenericCloud_LVM-qcow2-qcow2-x86_64-*-bios": 30,
                 "rocky-GenericCloud_LVM-qcow2-qcow2-x86_64-*-uefi": 30,
                 "rocky-dvd-iso-s390x-*-s390x": 40,
                 "rocky-dvd-iso-ppc64le-*-ppc64le": 40,
                 "rocky-dvd-iso-aarch64-*-aarch64": 40,
-                "rocky-dvd-iso-x86_64-*-64bit": 40
+                "rocky-dvd-iso-x86_64-*-bios": 40
             },
             "settings": {
                 "BOOTFROM": "c",
@@ -584,14 +584,14 @@
         },
         "base_service_manipulation": {
             "profiles": {
-                "rocky-GenericCloud_Base-qcow2-qcow2-x86_64-*-64bit": 30,
+                "rocky-GenericCloud_Base-qcow2-qcow2-x86_64-*-bios": 30,
                 "rocky-GenericCloud_Base-qcow2-qcow2-x86_64-*-uefi": 30,
-                "rocky-GenericCloud_LVM-qcow2-qcow2-x86_64-*-64bit": 30,
+                "rocky-GenericCloud_LVM-qcow2-qcow2-x86_64-*-bios": 30,
                 "rocky-GenericCloud_LVM-qcow2-qcow2-x86_64-*-uefi": 30,
                 "rocky-dvd-iso-s390x-*-s390x": 40,
                 "rocky-dvd-iso-ppc64le-*-ppc64le": 40,
                 "rocky-dvd-iso-aarch64-*-aarch64": 40,
-                "rocky-dvd-iso-x86_64-*-64bit": 40
+                "rocky-dvd-iso-x86_64-*-bios": 40
             },
             "settings": {
                 "BOOTFROM": "c",
@@ -605,9 +605,9 @@
         },
         "cloud_autocloud": {
             "profiles": {
-                "rocky-GenericCloud_Base-qcow2-qcow2-x86_64-*-64bit": 30,
+                "rocky-GenericCloud_Base-qcow2-qcow2-x86_64-*-bios": 30,
                 "rocky-GenericCloud_Base-qcow2-qcow2-x86_64-*-uefi": 30,
-                "rocky-GenericCloud_LVM-qcow2-qcow2-x86_64-*-64bit": 30,
+                "rocky-GenericCloud_LVM-qcow2-qcow2-x86_64-*-bios": 30,
                 "rocky-GenericCloud_LVM-qcow2-qcow2-x86_64-*-uefi": 30
             },
             "settings": {
@@ -619,7 +619,7 @@
                 "rocky-dvd-iso-s390x-*-s390x": 40,
                 "rocky-dvd-iso-ppc64le-*-ppc64le": 40,
                 "rocky-dvd-iso-aarch64-*-aarch64": 40,
-                "rocky-dvd-iso-x86_64-*-64bit": 40
+                "rocky-dvd-iso-x86_64-*-bios": 40
             },
             "settings": {
                 "DESKTOP": "false",
@@ -636,7 +636,7 @@
                 "rocky-universal-s390x-*-s390x": 20,
                 "rocky-universal-ppc64le-*-ppc64le": 20,
                 "rocky-universal-aarch64-*-aarch64": 20,
-                "rocky-universal-x86_64-*-64bit": 20
+                "rocky-universal-x86_64-*-bios": 20
             },
             "settings": {
                 "ANACONDA_TEXT": "1"
@@ -647,7 +647,7 @@
                 "rocky-universal-s390x-*-s390x": 40,
                 "rocky-universal-ppc64le-*-ppc64le": 40,
                 "rocky-universal-aarch64-*-aarch64": 40,
-                "rocky-universal-x86_64-*-64bit": 40
+                "rocky-universal-x86_64-*-bios": 40
             },
             "settings": {
                 "DESKTOP": "gnome",
@@ -667,7 +667,7 @@
                 "rocky-universal-s390x-*-s390x": 40,
                 "rocky-universal-ppc64le-*-ppc64le": 40,
                 "rocky-universal-aarch64-*-aarch64": 40,
-                "rocky-universal-x86_64-*-64bit": 40
+                "rocky-universal-x86_64-*-bios": 40
             },
             "settings": {
                 "DESKTOP": "gnome",
@@ -687,7 +687,7 @@
                 "rocky-dvd-iso-s390x-*-s390x": 40,
                 "rocky-dvd-iso-ppc64le-*-ppc64le": 40,
                 "rocky-dvd-iso-aarch64-*-aarch64": 40,
-                "rocky-dvd-iso-x86_64-*-64bit": 40,
+                "rocky-dvd-iso-x86_64-*-bios": 40,
                 "rocky-dvd-iso-x86_64-*-uefi": 41
             },
             "settings": {
@@ -704,7 +704,7 @@
                 "rocky-dvd-iso-s390x-*-s390x": 40,
                 "rocky-dvd-iso-ppc64le-*-ppc64le": 40,
                 "rocky-dvd-iso-aarch64-*-aarch64": 40,
-                "rocky-dvd-iso-x86_64-*-64bit": 40,
+                "rocky-dvd-iso-x86_64-*-bios": 40,
                 "rocky-dvd-iso-x86_64-*-uefi": 41
             },
             "settings": {
@@ -719,7 +719,7 @@
                 "rocky-universal-s390x-*-s390x": 40,
                 "rocky-universal-ppc64le-*-ppc64le": 40,
                 "rocky-universal-aarch64-*-aarch64": 40,
-                "rocky-universal-x86_64-*-64bit": 40,
+                "rocky-universal-x86_64-*-bios": 40,
                 "rocky-universal-x86_64-*-uefi": 41
             },
             "settings": {
@@ -736,7 +736,7 @@
                 "rocky-universal-s390x-*-s390x": 40,
                 "rocky-universal-ppc64le-*-ppc64le": 40,
                 "rocky-universal-aarch64-*-aarch64": 40,
-                "rocky-universal-x86_64-*-64bit": 40,
+                "rocky-universal-x86_64-*-bios": 40,
                 "rocky-universal-x86_64-*-uefi": 41
             },
             "settings": {
@@ -752,7 +752,7 @@
                 "rocky-universal-s390x-*-s390x": 40,
                 "rocky-universal-ppc64le-*-ppc64le": 40,
                 "rocky-universal-aarch64-*-aarch64": 40,
-                "rocky-universal-x86_64-*-64bit": 40
+                "rocky-universal-x86_64-*-bios": 40
             },
             "settings": {
                 "DESKTOP": "gnome",
@@ -772,7 +772,7 @@
                 "rocky-boot-iso-s390x-*-s390x": 10,
                 "rocky-boot-iso-ppc64le-*-ppc64le": 10,
                 "rocky-boot-iso-aarch64-*-aarch64": 10,
-                "rocky-boot-iso-x86_64-*-64bit": 10,
+                "rocky-boot-iso-x86_64-*-bios": 10,
                 "rocky-boot-iso-x86_64-*-uefi": 11,
                 "rocky-dvd-iso-s390x-*-s390x": 11,
                 "rocky-dvd-iso-ppc64le-*-ppc64le": 11,
@@ -790,12 +790,12 @@
                 "rocky-boot-iso-s390x-*-s390x": 10,
                 "rocky-boot-iso-ppc64le-*-ppc64le": 10,
                 "rocky-boot-iso-aarch64-*-aarch64": 10,
-                "rocky-boot-iso-x86_64-*-64bit": 10,
+                "rocky-boot-iso-x86_64-*-bios": 10,
                 "rocky-boot-iso-x86_64-*-uefi": 11,
                 "rocky-minimal-iso-s390x-*-s390x": 10,
                 "rocky-minimal-iso-ppc64le-*-ppc64le": 10,
                 "rocky-minimal-iso-aarch64-*-aarch64": 10,
-                "rocky-minimal-iso-x86_64-*-64bit": 10
+                "rocky-minimal-iso-x86_64-*-bios": 10
             },
             "settings": {
                 "PACKAGE_SET": "minimal",
@@ -807,7 +807,7 @@
                 "rocky-minimal-iso-s390x-*-s390x": 10,
                 "rocky-minimal-iso-ppc64le-*-ppc64le": 10,
                 "rocky-minimal-iso-aarch64-*-aarch64": 10,
-                "rocky-minimal-iso-x86_64-*-64bit": 10
+                "rocky-minimal-iso-x86_64-*-bios": 10
             },
             "settings": {
                 "PACKAGE_SET": "minimal",
@@ -820,7 +820,7 @@
                 "rocky-dvd-iso-s390x-*-s390x": 10,
                 "rocky-dvd-iso-ppc64le-*-ppc64le": 10,
                 "rocky-dvd-iso-aarch64-*-aarch64": 10,
-                "rocky-dvd-iso-x86_64-*-64bit": 10
+                "rocky-dvd-iso-x86_64-*-bios": 10
             },
             "settings": {
                 "DESKTOP": "gnome",
@@ -834,7 +834,7 @@
                 "rocky-universal-s390x-*-s390x": 30,
                 "rocky-universal-ppc64le-*-ppc64le": 30,
                 "rocky-universal-aarch64-*-aarch64": 30,
-                "rocky-universal-x86_64-*-64bit": 30,
+                "rocky-universal-x86_64-*-bios": 30,
                 "rocky-universal-x86_64-*-uefi": 31
             },
             "settings": {
@@ -850,7 +850,7 @@
                 "rocky-universal-s390x-*-s390x": 20,
                 "rocky-universal-ppc64le-*-ppc64le": 20,
                 "rocky-universal-aarch64-*-aarch64": 20,
-                "rocky-universal-x86_64-*-64bit": 20,
+                "rocky-universal-x86_64-*-bios": 20,
                 "rocky-universal-x86_64-*-uefi": 21
             },
             "settings": {
@@ -867,7 +867,7 @@
                 "rocky-universal-s390x-*-s390x": 40,
                 "rocky-universal-ppc64le-*-ppc64le": 40,
                 "rocky-universal-aarch64-*-aarch64": 40,
-                "rocky-universal-x86_64-*-64bit": 40
+                "rocky-universal-x86_64-*-bios": 40
             },
             "settings": {
                 "DESKTOP": "gnome",
@@ -885,7 +885,7 @@
         "install_iscsi": {
             "profiles": {
                 "rocky-universal-aarch64-*-aarch64": 40,
-                "rocky-universal-x86_64-*-64bit": 40
+                "rocky-universal-x86_64-*-bios": 40
             },
             "settings": {
                 "ANACONDA_STATIC": "172.16.2.111",
@@ -900,7 +900,7 @@
         "install_kickstart_nfs": {
             "profiles": {
                 "rocky-universal-aarch64-*-aarch64": 30,
-                "rocky-universal-x86_64-*-64bit": 30
+                "rocky-universal-x86_64-*-bios": 30
             },
             "settings": {
                 "GRUB": "inst.ks=nfs:172.16.2.110:/export/root-user-crypted-net.ks",
@@ -918,7 +918,7 @@
                 "rocky-universal-s390x-*-s390x": 40,
                 "rocky-universal-ppc64le-*-ppc64le": 40,
                 "rocky-universal-aarch64-*-aarch64": 40,
-                "rocky-universal-x86_64-*-64bit": 40,
+                "rocky-universal-x86_64-*-bios": 40,
                 "rocky-universal-x86_64-*-uefi": 41
             },
             "settings": {
@@ -933,7 +933,7 @@
                 "rocky-dvd-iso-s390x-*-s390x": 40,
                 "rocky-dvd-iso-ppc64le-*-ppc64le": 40,
                 "rocky-dvd-iso-aarch64-*-aarch64": 40,
-                "rocky-dvd-iso-x86_64-*-64bit": 40,
+                "rocky-dvd-iso-x86_64-*-bios": 40,
                 "rocky-dvd-iso-x86_64-*-uefi": 41
             },
             "settings": {
@@ -949,7 +949,7 @@
                 "rocky-dvd-iso-s390x-*-s390x": 30,
                 "rocky-dvd-iso-ppc64le-*-ppc64le": 30,
                 "rocky-dvd-iso-aarch64-*-aarch64": 30,
-                "rocky-dvd-iso-x86_64-*-64bit": 30,
+                "rocky-dvd-iso-x86_64-*-bios": 30,
                 "rocky-dvd-iso-x86_64-*-uefi": 31
             },
             "settings": {
@@ -963,7 +963,7 @@
                 "rocky-universal-s390x-*-s390x": 20,
                 "rocky-universal-ppc64le-*-ppc64le": 20,
                 "rocky-universal-aarch64-*-aarch64": 20,
-                "rocky-universal-x86_64-*-64bit": 20
+                "rocky-universal-x86_64-*-bios": 20
             },
             "settings": {
                 "MIRRORLIST_GRAPHICAL": "1",
@@ -975,7 +975,7 @@
                 "rocky-universal-s390x-*-s390x": 20,
                 "rocky-universal-ppc64le-*-ppc64le": 20,
                 "rocky-universal-aarch64-*-aarch64": 20,
-                "rocky-universal-x86_64-*-64bit": 20,
+                "rocky-universal-x86_64-*-bios": 20,
                 "rocky-universal-x86_64-*-uefi": 21
             },
             "settings": {
@@ -992,7 +992,7 @@
                 "rocky-universal-s390x-*-s390x": 30,
                 "rocky-universal-ppc64le-*-ppc64le": 30,
                 "rocky-universal-aarch64-*-aarch64": 30,
-                "rocky-universal-x86_64-*-64bit": 30,
+                "rocky-universal-x86_64-*-bios": 30,
                 "rocky-universal-x86_64-*-uefi": 31
             },
             "settings": {
@@ -1008,7 +1008,7 @@
                 "rocky-universal-s390x-*-s390x": 50,
                 "rocky-universal-ppc64le-*-ppc64le": 50,
                 "rocky-universal-aarch64-*-aarch64": 50,
-                "rocky-universal-x86_64-*-64bit": 50,
+                "rocky-universal-x86_64-*-bios": 50,
                 "rocky-universal-x86_64-*-uefi": 51
             },
             "settings": {
@@ -1020,7 +1020,7 @@
         },
         "install_package_set_minimal": {
             "profiles": {
-                "rocky-package-set-x86_64-*-64bit": 30
+                "rocky-package-set-x86_64-*-bios": 30
             },
             "settings": {
                 "DESKTOP": "false",
@@ -1029,7 +1029,7 @@
         },
         "install_package_set_server": {
             "profiles": {
-                "rocky-package-set-x86_64-*-64bit": 30
+                "rocky-package-set-x86_64-*-bios": 30
             },
             "settings": {
                 "DESKTOP": "false",
@@ -1038,7 +1038,7 @@
         },
         "install_package_set_graphical-server": {
             "profiles": {
-                "rocky-package-set-x86_64-*-64bit": 30
+                "rocky-package-set-x86_64-*-bios": 30
             },
             "settings": {
                 "DESKTOP": "gnome",
@@ -1047,7 +1047,7 @@
         },
         "install_package_set_workstation": {
             "profiles": {
-                "rocky-package-set-x86_64-*-64bit": 30
+                "rocky-package-set-x86_64-*-bios": 30
             },
             "settings": {
                 "DESKTOP": "gnome",
@@ -1056,7 +1056,7 @@
         },
         "install_package_set_virtualization-host": {
             "profiles": {
-                "rocky-package-set-x86_64-*-64bit": 30
+                "rocky-package-set-x86_64-*-bios": 30
             },
             "settings": {
                 "DESKTOP": "false",
@@ -1066,7 +1066,7 @@
         "install_pxeboot": {
             "profiles": {
                 "rocky-universal-aarch64-*-aarch64": 30,
-                "rocky-universal-x86_64-*-64bit": 30,
+                "rocky-universal-x86_64-*-bios": 30,
                 "rocky-universal-x86_64-*-uefi": 31
             },
             "settings": {
@@ -1087,7 +1087,7 @@
                 "rocky-universal-s390x-*-s390x": 20,
                 "rocky-universal-ppc64le-*-ppc64le": 20,
                 "rocky-universal-aarch64-*-aarch64": 20,
-                "rocky-universal-x86_64-*-64bit": 20
+                "rocky-universal-x86_64-*-bios": 20
             },
             "settings": {
                 "REPOSITORY_GRAPHICAL": "%LOCATION%",
@@ -1100,7 +1100,7 @@
                 "rocky-universal-s390x-*-s390x": 20,
                 "rocky-universal-ppc64le-*-ppc64le": 20,
                 "rocky-universal-aarch64-*-aarch64": 20,
-                "rocky-universal-x86_64-*-64bit": 20
+                "rocky-universal-x86_64-*-bios": 20
             },
             "settings": {
                 "REPOSITORY_VARIATION": "%LOCATION%",
@@ -1113,7 +1113,7 @@
                 "rocky-dvd-iso-s390x-*-s390x": 30,
                 "rocky-dvd-iso-ppc64le-*-ppc64le": 30,
                 "rocky-dvd-iso-aarch64-*-aarch64": 30,
-                "rocky-dvd-iso-x86_64-*-64bit": 30
+                "rocky-dvd-iso-x86_64-*-bios": 30
             },
             "settings": {
                 "INSTALL_UNLOCK": "support_ready",
@@ -1126,7 +1126,7 @@
         "install_repository_nfs_variation": {
             "profiles": {
                 "rocky-dvd-iso-aarch64-*-aarch64": 30,
-                "rocky-dvd-iso-x86_64-*-64bit": 30
+                "rocky-dvd-iso-x86_64-*-bios": 30
             },
             "settings": {
                 "INSTALL_UNLOCK": "support_ready",
@@ -1139,7 +1139,7 @@
         "install_repository_nfsiso_variation": {
             "profiles": {
                 "rocky-dvd-iso-aarch64-*-aarch64": 30,
-                "rocky-dvd-iso-x86_64-*-64bit": 30
+                "rocky-dvd-iso-x86_64-*-bios": 30
             },
             "settings": {
                 "INSTALL_UNLOCK": "support_ready",
@@ -1154,7 +1154,7 @@
                 "rocky-universal-s390x-*-s390x": 31,
                 "rocky-universal-ppc64le-*-ppc64le": 31,
                 "rocky-universal-aarch64-*-aarch64": 31,
-                "rocky-universal-x86_64-*-64bit": 31,
+                "rocky-universal-x86_64-*-bios": 31,
                 "rocky-universal-x86_64-*-uefi": 32
             },
             "settings": {
@@ -1169,7 +1169,7 @@
                 "rocky-universal-s390x-*-s390x": 20,
                 "rocky-universal-ppc64le-*-ppc64le": 20,
                 "rocky-universal-aarch64-*-aarch64": 20,
-                "rocky-universal-x86_64-*-64bit": 20,
+                "rocky-universal-x86_64-*-bios": 20,
                 "rocky-universal-x86_64-*-uefi": 21
             },
             "settings": {
@@ -1182,7 +1182,7 @@
         "install_scsi_updates_img": {
             "profiles": {
                 "rocky-universal-aarch64-*-aarch64": 20,
-                "rocky-universal-x86_64-*-64bit": 20
+                "rocky-universal-x86_64-*-bios": 20
             },
             "settings": {
                 "CDMODEL": "scsi-cd",
@@ -1199,7 +1199,7 @@
                 "rocky-universal-s390x-*-s390x": 30,
                 "rocky-universal-ppc64le-*-ppc64le": 30,
                 "rocky-universal-aarch64-*-aarch64": 30,
-                "rocky-universal-x86_64-*-64bit": 30
+                "rocky-universal-x86_64-*-bios": 30
             },
             "settings": {
                 "ANACONDA_TEXT": "1",
@@ -1213,7 +1213,7 @@
                 "rocky-universal-s390x-*-s390x": 40,
                 "rocky-universal-ppc64le-*-ppc64le": 40,
                 "rocky-universal-aarch64-*-aarch64": 40,
-                "rocky-universal-x86_64-*-64bit": 40
+                "rocky-universal-x86_64-*-bios": 40
             },
             "settings": {
                 "HDD_1": "disk_shrink_ext4.img",
@@ -1228,7 +1228,7 @@
                 "rocky-universal-s390x-*-s390x": 40,
                 "rocky-universal-ppc64le-*-ppc64le": 40,
                 "rocky-universal-aarch64-*-aarch64": 40,
-                "rocky-universal-x86_64-*-64bit": 40
+                "rocky-universal-x86_64-*-bios": 40
             },
             "settings": {
                 "HDD_1": "disk_shrink_ntfs.img",
@@ -1241,7 +1241,7 @@
         "install_simple_encrypted": {
             "profiles": {
                 "rocky-universal-aarch64-*-aarch64": 30,
-                "rocky-universal-x86_64-*-64bit": 30,
+                "rocky-universal-x86_64-*-bios": 30,
                 "rocky-universal-x86_64-*-uefi": 31
             },
             "settings": {
@@ -1256,7 +1256,7 @@
                 "rocky-universal-s390x-*-s390x": 30,
                 "rocky-universal-ppc64le-*-ppc64le": 30,
                 "rocky-universal-aarch64-*-aarch64": 30,
-                "rocky-universal-x86_64-*-64bit": 30,
+                "rocky-universal-x86_64-*-bios": 30,
                 "rocky-universal-x86_64-*-uefi": 31
             },
             "settings": {
@@ -1273,7 +1273,7 @@
                 "rocky-universal-s390x-*-s390x": 30,
                 "rocky-universal-ppc64le-*-ppc64le": 30,
                 "rocky-universal-aarch64-*-aarch64": 30,
-                "rocky-universal-x86_64-*-64bit": 30,
+                "rocky-universal-x86_64-*-bios": 30,
                 "rocky-universal-x86_64-*-uefi": 31
             },
             "settings": {
@@ -1287,7 +1287,7 @@
         "install_updates_nfs": {
             "profiles": {
                 "rocky-dvd-iso-aarch64-*-aarch64": 40,
-                "rocky-dvd-iso-x86_64-*-64bit": 40
+                "rocky-dvd-iso-x86_64-*-bios": 40
             },
             "settings": {
                 "GRUB": "inst.stage2=nfs:nfsvers=4:172.16.2.110:/repo",
@@ -1302,7 +1302,7 @@
         "install_vnc_client": {
             "profiles": {
                 "rocky-dvd-iso-aarch64-*-aarch64": 40,
-                "rocky-dvd-iso-x86_64-*-64bit": 40
+                "rocky-dvd-iso-x86_64-*-bios": 40
             },
             "settings": {
                 "BOOTFROM": "c",
@@ -1319,7 +1319,7 @@
         "install_vnc_server": {
             "profiles": {
                 "rocky-dvd-iso-aarch64-*-aarch64": 40,
-                "rocky-dvd-iso-x86_64-*-64bit": 40
+                "rocky-dvd-iso-x86_64-*-bios": 40
             },
             "settings": {
                 "GRUB": "inst.vnc net.ifnames=0 biosdevname=0 ip=172.16.2.114::172.16.2.2:255.255.255.0:vnc001.test.openqa.rockylinux.org:eth0:off",
@@ -1331,7 +1331,7 @@
         "install_vncconnect_client": {
             "profiles": {
                 "rocky-dvd-iso-aarch64-*-aarch64": 40,
-                "rocky-dvd-iso-x86_64-*-64bit": 40
+                "rocky-dvd-iso-x86_64-*-bios": 40
             },
             "settings": {
                 "BOOTFROM": "c",
@@ -1347,7 +1347,7 @@
         "install_vncconnect_server": {
             "profiles": {
                 "rocky-dvd-iso-aarch64-*-aarch64": 40,
-                "rocky-dvd-iso-x86_64-*-64bit": 40
+                "rocky-dvd-iso-x86_64-*-bios": 40
             },
             "settings": {
                 "GRUB": "inst.vnc inst.vncconnect=172.16.2.117:5500 net.ifnames=0 biosdevname=0 ip=172.16.2.116::172.16.2.2:255.255.255.0:vnc003.test.openqa.rockylinux.org:eth0:off",
@@ -1363,7 +1363,7 @@
                 "rocky-universal-s390x-*-s390x": 40,
                 "rocky-universal-ppc64le-*-ppc64le": 40,
                 "rocky-universal-aarch64-*-aarch64": 40,
-                "rocky-universal-x86_64-*-64bit": 40,
+                "rocky-universal-x86_64-*-bios": 40,
                 "rocky-universal-x86_64-*-uefi": 41
             },
             "settings": {
@@ -1378,7 +1378,7 @@
                 "rocky-universal-s390x-*-s390x": 30,
                 "rocky-universal-ppc64le-*-ppc64le": 30,
                 "rocky-universal-aarch64-*-aarch64": 30,
-                "rocky-universal-x86_64-*-64bit": 30
+                "rocky-universal-x86_64-*-bios": 30
             },
             "settings": {
                 "ENTRYPOINT": "memtest"
@@ -1389,7 +1389,7 @@
                 "rocky-dvd-iso-s390x-*-s390x": 30,
                 "rocky-dvd-iso-ppc64le-*-ppc64le": 30,
                 "rocky-dvd-iso-aarch64-*-aarch64": 30,
-                "rocky-dvd-iso-x86_64-*-64bit": 30
+                "rocky-dvd-iso-x86_64-*-bios": 30
             },
             "settings": {
                 "BOOTFROM": "c",
@@ -1404,7 +1404,7 @@
         "realmd_join_cockpit": {
             "profiles": {
                 "rocky-dvd-iso-aarch64-*-aarch64": 30,
-                "rocky-dvd-iso-x86_64-*-64bit": 30
+                "rocky-dvd-iso-x86_64-*-bios": 30
             },
             "settings": {
                 "+HDD_1": "disk_%MACHINE%_cockpit.qcow2",
@@ -1422,7 +1422,7 @@
         "realmd_join_sssd": {
             "profiles": {
                 "rocky-dvd-iso-aarch64-*-aarch64": 20,
-                "rocky-dvd-iso-x86_64-*-64bit": 20
+                "rocky-dvd-iso-x86_64-*-bios": 20
             },
             "settings": {
                 "BOOTFROM": "c",
@@ -1442,7 +1442,7 @@
                 "rocky-dvd-iso-s390x-*-s390x": 40,
                 "rocky-dvd-iso-ppc64le-*-ppc64le": 40,
                 "rocky-dvd-iso-aarch64-*-aarch64": 40,
-                "rocky-dvd-iso-x86_64-*-64bit": 40
+                "rocky-dvd-iso-x86_64-*-bios": 40
             },
             "settings": {
                 "BOOTFROM": "c",
@@ -1455,7 +1455,7 @@
         "server_cockpit_basic": {
             "profiles": {
                 "rocky-dvd-iso-aarch64-*-aarch64": 30,
-                "rocky-dvd-iso-x86_64-*-64bit": 30
+                "rocky-dvd-iso-x86_64-*-bios": 30
             },
             "settings": {
                 "+HDD_1": "disk_%MACHINE%_cockpit.qcow2",
@@ -1469,7 +1469,7 @@
         "server_cockpit_default": {
             "profiles": {
                 "rocky-dvd-iso-aarch64-*-aarch64": 20,
-                "rocky-dvd-iso-x86_64-*-64bit": 20
+                "rocky-dvd-iso-x86_64-*-bios": 20
             },
             "settings": {
                 "BOOTFROM": "c",
@@ -1485,7 +1485,7 @@
         "server_cockpit_updates": {
             "profiles": {
                 "rocky-dvd-iso-aarch64-*-aarch64": 30,
-                "rocky-dvd-iso-x86_64-*-64bit": 30
+                "rocky-dvd-iso-x86_64-*-bios": 30
             },
             "settings": {
                 "+HDD_1": "disk_%MACHINE%_cockpit.qcow2",
@@ -1499,7 +1499,7 @@
         "server_database_client": {
             "profiles": {
                 "rocky-dvd-iso-aarch64-*-aarch64": 30,
-                "rocky-dvd-iso-x86_64-*-64bit": 30
+                "rocky-dvd-iso-x86_64-*-bios": 30
             },
             "settings": {
                 "BOOTFROM": "c",
@@ -1519,7 +1519,7 @@
                 "rocky-dvd-iso-s390x-*-s390x": 20,
                 "rocky-dvd-iso-ppc64le-*-ppc64le": 20,
                 "rocky-dvd-iso-aarch64-*-aarch64": 20,
-                "rocky-dvd-iso-x86_64-*-64bit": 20
+                "rocky-dvd-iso-x86_64-*-bios": 20
             },
             "settings": {
                 "BOOTFROM": "c",
@@ -1536,7 +1536,7 @@
                 "rocky-dvd-iso-s390x-*-s390x": 20,
                 "rocky-dvd-iso-ppc64le-*-ppc64le": 20,
                 "rocky-dvd-iso-aarch64-*-aarch64": 20,
-                "rocky-dvd-iso-x86_64-*-64bit": 20
+                "rocky-dvd-iso-x86_64-*-bios": 20
             },
             "settings": {
                 "BOOTFROM": "c",
@@ -1549,7 +1549,7 @@
         "server_freeipa_replication_client": {
             "profiles": {
                 "rocky-dvd-iso-aarch64-*-aarch64": 30,
-                "rocky-dvd-iso-x86_64-*-64bit": 20
+                "rocky-dvd-iso-x86_64-*-bios": 20
             },
             "settings": {
                 "BOOTFROM": "c",
@@ -1568,7 +1568,7 @@
         "server_freeipa_replication_master": {
             "profiles": {
                 "rocky-dvd-iso-aarch64-*-aarch64": 30,
-                "rocky-dvd-iso-x86_64-*-64bit": 20
+                "rocky-dvd-iso-x86_64-*-bios": 20
             },
             "settings": {
                 "BOOTFROM": "c",
@@ -1587,7 +1587,7 @@
         "server_freeipa_replication_replica": {
             "profiles": {
                 "rocky-dvd-iso-aarch64-*-aarch64": 30,
-                "rocky-dvd-iso-x86_64-*-64bit": 20
+                "rocky-dvd-iso-x86_64-*-bios": 20
             },
             "settings": {
                 "BOOTFROM": "c",
@@ -1607,7 +1607,7 @@
         "server_realmd_join_kickstart": {
             "profiles": {
                 "rocky-dvd-iso-aarch64-*-aarch64": 20,
-                "rocky-dvd-iso-x86_64-*-64bit": 20
+                "rocky-dvd-iso-x86_64-*-bios": 20
             },
             "settings": {
                 "GRUB": "inst.ks=hd:vdb1:/freeipaclient.ks",
@@ -1626,7 +1626,7 @@
         "server_remote_logging_client": {
             "profiles": {
                 "rocky-dvd-iso-aarch64-*-aarch64": 20,
-                "rocky-dvd-iso-x86_64-*-64bit": 20
+                "rocky-dvd-iso-x86_64-*-bios": 20
             },
             "settings": {
                 "BOOTFROM": "c",
@@ -1644,7 +1644,7 @@
         "server_remote_logging_server": {
             "profiles": {
                 "rocky-dvd-iso-aarch64-*-aarch64": 20,
-                "rocky-dvd-iso-x86_64-*-64bit": 20
+                "rocky-dvd-iso-x86_64-*-bios": 20
             },
             "settings": {
                 "BOOTFROM": "c",
@@ -1662,7 +1662,7 @@
         "server_role_deploy_database_server": {
             "profiles": {
                 "rocky-dvd-iso-aarch64-*-aarch64": 20,
-                "rocky-dvd-iso-x86_64-*-64bit": 20
+                "rocky-dvd-iso-x86_64-*-bios": 20
             },
             "settings": {
                 "BOOTFROM": "c",
@@ -1680,7 +1680,7 @@
         "server_role_deploy_domain_controller": {
             "profiles": {
                 "rocky-dvd-iso-aarch64-*-aarch64": 20,
-                "rocky-dvd-iso-x86_64-*-64bit": 20
+                "rocky-dvd-iso-x86_64-*-bios": 20
             },
             "settings": {
                 "BOOTFROM": "c",
@@ -1698,7 +1698,7 @@
         "slurm22": {
             "profiles": {
                 "rocky-dvd-iso-aarch64-*-aarch64": 10,
-                "rocky-dvd-iso-x86_64-*-64bit": 10
+                "rocky-dvd-iso-x86_64-*-bios": 10
             },
             "settings": {
                 "BOOTFROM": "c",
@@ -1713,7 +1713,7 @@
         "slurm23": {
             "profiles": {
                 "rocky-dvd-iso-aarch64-*-aarch64": 10,
-                "rocky-dvd-iso-x86_64-*-64bit": 10
+                "rocky-dvd-iso-x86_64-*-bios": 10
             },
             "settings": {
                 "BOOTFROM": "c",
@@ -1728,9 +1728,9 @@
         "support_server": {
             "profiles": {
                 "rocky-dvd-iso-aarch64-*-aarch64": 10,
-                "rocky-dvd-iso-x86_64-*-64bit": 10,
+                "rocky-dvd-iso-x86_64-*-bios": 10,
                 "rocky-universal-aarch64-*-aarch64": 10,
-                "rocky-universal-x86_64-*-64bit": 10
+                "rocky-universal-x86_64-*-bios": 10
             },
             "settings": {
                 "BOOTFROM": "c",
@@ -1749,7 +1749,7 @@
         "toolbox": {
             "profiles": {
                 "rocky-dvd-iso-aarch64-*-aarch64": 10,
-                "rocky-dvd-iso-x86_64-*-64bit": 10
+                "rocky-dvd-iso-x86_64-*-bios": 10
             },
             "settings": {
                 "BOOTFROM": "c",

--- a/templates.fif.json
+++ b/templates.fif.json
@@ -83,6 +83,28 @@
                 "UEFI_PFLASH_VARS": "/usr/share/edk2/ovmf/OVMF_VARS.fd",
                 "WORKER_CLASS": "qemu_x86_64"
             }
+        },
+        "uesb": {
+            "backend": "qemu",
+            "settings": {
+                "ARCH_BASE_MACHINE": "64bit",
+                "PART_TABLE_TYPE": "gpt",
+                "QEMUCPU": "Nehalem",
+                "QEMUCPUS": "2",
+                "QEMURAM": "3072",
+                "QEMU_VIDEO_DEVICE": "virtio-vga",
+                "XRES": "1024",
+                "YRES": "768",
+                "QEMUMACHINE": "q35,smm=on",
+                "QEMU_APPEND": "global driver=cfi.pflash01,property=secure,value=on",
+                "QEMU_MAX_MIGRATION_TIME": "480",
+                "QEMU_VIRTIO_RNG": "1",
+                "UEFI": "1",
+                "UEFI_PFLASH_CODE": "/usr/share/edk2/ovmf/OVMF_CODE.secboot.fd",
+                "UEFI_PFLASH_VARS": "/usr/share/edk2/ovmf/OVMF_VARS.secboot.fd",
+                "UEFI_SECURE": "1",
+                "WORKER_CLASS": "qemu_x86_64"
+            }
         }
     },
     "Products": {

--- a/tests/_secure_boot_fallback.pm
+++ b/tests/_secure_boot_fallback.pm
@@ -10,7 +10,7 @@ sub run {
     }
     script_run 'efibootmgr';
     # now try deleting the "rocky" boot entry and rebooting, to check the fallback path
-    assert_script_run('efibootmgr -b $(efibootmgr | grep rocky | cut -f1 | sed -e "s,[^0-9],,g") -B');
+    assert_script_run('efibootmgr -b $(efibootmgr | grep -i rocky | cut -f1 | sed -e "s,[^0-9],,g") -B');
     # check that worked
     validate_script_output('efibootmgr', sub { $_ !~ m/.*rocky.*/s });
     type_string("reboot\n");

--- a/tests/_secure_boot_fallback.pm
+++ b/tests/_secure_boot_fallback.pm
@@ -1,0 +1,29 @@
+use base "installedtest";
+use strict;
+use testapi;
+use utils;
+
+sub run {
+    my $self = shift;
+    if (not(check_screen "root_console", 0)) {
+        $self->root_console(tty => 4);
+    }
+    script_run 'efibootmgr';
+    # now try deleting the "rocky" boot entry and rebooting, to check the fallback path
+    assert_script_run('efibootmgr -b $(efibootmgr | grep rocky | cut -f1 | sed -e "s,[^0-9],,g") -B');
+    # check that worked
+    validate_script_output('efibootmgr', sub { $_ !~ m/.*rocky.*/s });
+    type_string("reboot\n");
+    boot_to_login_screen;
+    $self->root_console(tty => 3);
+    # rocky entry should have been recreated
+    validate_script_output('efibootmgr', sub { m/rocky/ });
+    # SB should still be enabled
+    validate_script_output('mokutil --sb-state', sub { m/SecureBoot enabled/ });
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;


### PR DESCRIPTION
This enables secure boot in machine type uefi. It incorporates #217 and will supercede it if merged first.
It has a fallback to uefi non-secure boot in machine type uefx to allow us easily to recover testing capability if qemu ability to run as secure should fail for some reason.

Tested:  Set of FLAVORS boot-iso dvd-iso and universal.  (minimal-iso and package-set are bios only)

![Screenshot 2024-07-03 at 09-50-02 openQA rocky-9 4-universal-x86_64-Build-20240703 092844 0-universal-9 4-install_with_swap@uefi test results](https://github.com/rocky-linux/os-autoinst-distri-rocky/assets/3416699/70251d14-596a-4d69-a9b3-25c3f3d5bae1)

Results: Identical to previous #217 runs except all uefi results have  "SecureBoot enabled" message in uefi_postinstall test.