### PR TITLE
testsuite: use configured username and password in autocloud test

### DIFF
--- a/tests/autocloud.pm
+++ b/tests/autocloud.pm
@@ -28,7 +28,7 @@ sub run {
     # let's go to another tty and login as regular user
     send_key "alt-f2";
     console_login(user => get_var("USER_LOGIN", "test"), password => get_var("USER_PASSWORD", "weakpassword"));
-    assert_script_run "curl -O https://fedorapeople.org/groups/qa/tunirtests.tar.gz";
+    assert_script_run "curl -O https://openqa.rockylinux.org/qa/tunirtests.tar.gz";
     assert_script_run "tar xvf tunirtests.tar.gz";
     assert_script_run "sudo python3 -m unittest tunirtests.atomictests.TestAtomic01Status -v";
     _soft_fail_run "tunirtests.nongatingtests.TunirNonGatingtests";

--- a/tests/autocloud.pm
+++ b/tests/autocloud.pm
@@ -19,6 +19,10 @@ sub run {
     # autocloud used to use, via tunir and this tunir config:
     # https://infrastructure.fedoraproject.org/cgit/ansible.git/tree/roles/autocloud/backend/files/fedora.txt?id=6e7c1b90593df8371fd34ed9484bd4da119236d3
     my $self = shift;
+    # tests require python3 which is not default installed in Rocky 8
+    if (get_version_major() < 9) {
+        assert_script_run("dnf install -y python3", timeout => 240);
+    }
     # we need to use script_run as regular user
     assert_script_run "chmod ugo+w /dev/" . $serialdev;
     # let's go to another tty and login as regular user

--- a/tests/autocloud.pm
+++ b/tests/autocloud.pm
@@ -23,7 +23,7 @@ sub run {
     assert_script_run "chmod ugo+w /dev/" . $serialdev;
     # let's go to another tty and login as regular user
     send_key "alt-f2";
-    console_login(user => "test", password => "weakpassword");
+    console_login(user => get_var("USER_LOGIN", "test"), password => get_var("USER_PASSWORD", "weakpassword"));
     assert_script_run "curl -O https://fedorapeople.org/groups/qa/tunirtests.tar.gz";
     assert_script_run "tar xvf tunirtests.tar.gz";
     assert_script_run "sudo python3 -m unittest tunirtests.atomictests.TestAtomic01Status -v";
@@ -45,19 +45,19 @@ sub run {
     assert_script_run "sudo python3 -m unittest tunirtests.cloudservice.TestServiceDisable -v";
     type_string "sudo reboot\n";
     boot_to_login_screen(timeout => 180);
-    console_login(user => "root", password => "weakpassword");
+    console_login(user => "root", password => get_var("USER_PASSWORD", "weakpassword"));
     # we need to use script_run as regular user again
     assert_script_run "sudo chmod ugo+w /dev/" . $serialdev;
     # let's go to another tty and login as regular user again
     send_key "alt-f2";
-    console_login(user => "test", password => "weakpassword");
+    console_login(user => get_var("USER_LOGIN", "test"), password => get_var("USER_PASSWORD", "weakpassword"));
     _soft_fail_run "tunirtests.testreboot.TestReboot";
     assert_script_run "sudo python3 -m unittest tunirtests.cloudservice.TestServiceManipulation -v";
     # this test only works properly as a regular user
     _soft_fail_run "tunirtests.cloudtests.TestJournalWrittenAfterReboot", 0;
     type_string "sudo reboot\n";
     boot_to_login_screen(timeout => 180);
-    console_login(user => "root", password => "weakpassword");
+    console_login(user => "root", get_var("USER_PASSWORD", "weakpassword"));
     # we need to use script_run as regular user again
     assert_script_run "sudo chmod ugo+w /dev/" . $serialdev;
     # let's go to another tty and login as regular user again

--- a/tests/autocloud.pm
+++ b/tests/autocloud.pm
@@ -66,7 +66,7 @@ sub run {
     assert_script_run "sudo chmod ugo+w /dev/" . $serialdev;
     # let's go to another tty and login as regular user again
     send_key "alt-f2";
-    console_login(user => "test", password => "weakpassword");
+    console_login(user => get_var("USER_LOGIN", "test"), password => get_var("USER_PASSWORD", "weakpassword"));
     assert_script_run "sudo python3 -m unittest tunirtests.cloudservice.TestServiceAfter -v";
     assert_script_run "sudo python3 -m unittest tunirtests.atomictests.TestDockerInstalled -v";
     assert_script_run "sudo python3 -m unittest tunirtests.atomictests.TestDockerStorageSetup -v";


### PR DESCRIPTION
The PR changes `autocloud.pm` to use the `USER_LOGIN` and `USER_PASSWORD` provided in the test `POST` while falling back to default values if not provided.

The upstream Turin tests have been verified to operate as written with only perhaps one exception and will be updated once user login to the running GenericCloud image is working.

If / when changes are required we can provide our own tarball of tests to supplement this openQA test suite.

PR runs for Rocky 8 and Rocky 9 are complete and demonstrate this issue is resolved and remaining issues must be resolved with further modifications to `autocloud` (for Rocky 8 `python3` must be installed to run the tests) or the upstream provided tests (test fails to install package `pss` which doesn't exist in Rocky Linux).

Rocky 8 autocloud - https://openqa.rockylinux.org/tests/147481#step/autocloud/6
Rocky 9 autocloud - https://openqa.rockylinux.org/tests/147480#step/autocloud/6

Additional runs after adding more changes complete the ability to login and run tests...

Rocky 8 autocloud - https://openqa.rockylinux.org/tests/147765
Rocky 9 autocloud - https://openqa.rockylinux.org/tests/147764

...with the Rocky 8 being only a soft-failure and the Rocky 9 failure being related failure of `kdump.service` on startup  which can be investigated.

The intent of this PR is satisfied.