### PR TITLE
testsuite: Update cloud autocloud

### DIFF
--- a/tests/autocloud.pm
+++ b/tests/autocloud.pm
@@ -32,7 +32,6 @@ sub run {
     assert_script_run "tar xvf tunirtests.tar.gz";
     assert_script_run "sudo python3 -m unittest tunirtests.atomictests.TestAtomic01Status -v";
     _soft_fail_run "tunirtests.nongatingtests.TunirNonGatingtests";
-    _soft_fail_run "tunirtests.nongatingtests.TunirNonGatingtestBzip2";
     _soft_fail_run "tunirtests.nongatingtests.TunirNonGatingtestsCpio";
     _soft_fail_run "tunirtests.nongatingtests.TunirNonGatingtestDiffutills";
     _soft_fail_run "tunirtests.nongatingtests.TunirNonGatingtestaudit";

--- a/tests/autocloud.pm
+++ b/tests/autocloud.pm
@@ -42,7 +42,7 @@ sub run {
     assert_script_run "sudo python3 -m unittest tunirtests.cloudtests.Testtmpmount -v";
     assert_script_run "sudo python3 -m unittest tunirtests.cloudtests.Testnetname -v";
     # this test only works properly as a regular user
-    _soft_fail_run "tunirtests.cloudtests.TestJournalWritten", 0;
+    #_soft_fail_run "tunirtests.cloudtests.TestJournalWritten", 0;
     assert_script_run "sudo python3 -m unittest tunirtests.cloudservice.TestServiceStop -v";
     assert_script_run "sudo python3 -m unittest tunirtests.cloudservice.TestServiceDisable -v";
     type_string "sudo reboot\n";
@@ -56,7 +56,7 @@ sub run {
     _soft_fail_run "tunirtests.testreboot.TestReboot";
     assert_script_run "sudo python3 -m unittest tunirtests.cloudservice.TestServiceManipulation -v";
     # this test only works properly as a regular user
-    _soft_fail_run "tunirtests.cloudtests.TestJournalWrittenAfterReboot", 0;
+    #_soft_fail_run "tunirtests.cloudtests.TestJournalWrittenAfterReboot", 0;
     type_string "sudo reboot\n";
     boot_to_login_screen(timeout => 180);
     console_login(user => "root", get_var("USER_PASSWORD", "weakpassword"));

--- a/tests/autocloud.pm
+++ b/tests/autocloud.pm
@@ -29,7 +29,7 @@ sub run {
     send_key "alt-f2";
     console_login(user => get_var("USER_LOGIN", "test"), password => get_var("USER_PASSWORD", "weakpassword"));
     assert_script_run "curl -O https://openqa.rockylinux.org/qa/tunirtests.tar.gz";
-    assert_script_run "tar xvf tunirtests.tar.gz";
+    assert_script_run "tar -xvzf tunirtests.tar.gz";
     assert_script_run "sudo python3 -m unittest tunirtests.atomictests.TestAtomic01Status -v";
     _soft_fail_run "tunirtests.nongatingtests.TunirNonGatingtests";
     _soft_fail_run "tunirtests.nongatingtests.TunirNonGatingtestsCpio";

--- a/tests/autocloud.pm
+++ b/tests/autocloud.pm
@@ -30,7 +30,6 @@ sub run {
     console_login(user => get_var("USER_LOGIN", "test"), password => get_var("USER_PASSWORD", "weakpassword"));
     assert_script_run "curl -O https://openqa.rockylinux.org/qa/tunirtests.tar.gz";
     assert_script_run "tar -xvzf tunirtests.tar.gz";
-    assert_script_run "sudo python3 -m unittest tunirtests.atomictests.TestAtomic01Status -v";
     _soft_fail_run "tunirtests.nongatingtests.TunirNonGatingtests";
     _soft_fail_run "tunirtests.nongatingtests.TunirNonGatingtestsCpio";
     _soft_fail_run "tunirtests.nongatingtests.TunirNonGatingtestDiffutills";
@@ -67,14 +66,6 @@ sub run {
     send_key "alt-f2";
     console_login(user => get_var("USER_LOGIN", "test"), password => get_var("USER_PASSWORD", "weakpassword"));
     assert_script_run "sudo python3 -m unittest tunirtests.cloudservice.TestServiceAfter -v";
-    assert_script_run "sudo python3 -m unittest tunirtests.atomictests.TestDockerInstalled -v";
-    assert_script_run "sudo python3 -m unittest tunirtests.atomictests.TestDockerStorageSetup -v";
-    assert_script_run "sudo python3 -m unittest tunirtests.atomictests.TestAtomicFirstBootRun -v";
-    assert_script_run "sudo python3 -m unittest tunirtests.atomictests.TestAtomicCommand -v";
-    assert_script_run "sudo python3 -m unittest tunirtests.atomictests.TestAtomicDockerImage -v";
-    assert_script_run "sudo python3 -m unittest tunirtests.atomictests.TestRootMount -v";
-    assert_script_run "sudo python3 -m unittest tunirtests.atomictests.Testreadonlymount -v";
-    assert_script_run "sudo python3 -m unittest tunirtests.atomictests.TestDockerDaemon -v";
 }
 
 


### PR DESCRIPTION
This PR changes `autocloud.pm` disabling upstream Atomic Tunir tests, temporarily disables some `systemd-journald` tests and canonicalizes test archive format and filename to reduce confusion.

After PR runs for Rocky 8 and Rocky 9 are complete those runs will be added to this description and the PR will move from DRAFT state to be considered for final review.

Rocky 8 autocloud - [https://openqa.rockylinux.org/tests/156289](https://openqa.rockylinux.org/tests/156289) - **PASS**
Rocky 9 autocloud - [https://openqa.rockylinux.org/tests/156290](https://openqa.rockylinux.org/tests/156290) - **FAIL**

_NOTE: The items addressed in this PR for Rocky 9 autocloud are resolved. The test fails due to a problem with startup of `kdump.service` which can only be resolved by modifying the build process of the Rocky 9 GenericCloud images and is **out of scope** for this PR._