### PR TITLE
needles: update match area and add missing click-point

### DIFF
--- a/needles/anaconda/install_destination/arabic/rocky-encrypt_data_arabic-untranslated-gtk3245-20240508.json
+++ b/needles/anaconda/install_destination/arabic/rocky-encrypt_data_arabic-untranslated-gtk3245-20240508.json
@@ -3,9 +3,13 @@
     {
       "ypos": 544,
       "height": 23,
-      "width": 127,
-      "xpos": 786,
-      "type": "match"
+      "width": 259,
+      "xpos": 747,
+      "type": "match",
+      "click_point": {
+        "xpos": 246,
+        "ypos": 12
+      }
     }
   ],
   "properties": [],


### PR DESCRIPTION
This PR fixes a needle provided in #214 when adding support for `aarch64` that was missing a `click_point` definition in the needle JSON.

This omission was causing failure of the `disk_guided_encrypted` test in the `install_arabic_language` test suite most recently visible in... [rocky-9.4-universal-x86_64-Build20240928-Rocky-9.4-x86_64.0-install_arabic_language@uefi](https://openqa.rockylinux.org/tests/166378).

The needle json was repaired in production system to allow test to complete successfully, most recently in [rocky-9.4-universal-x86_64-Build20240928-Rocky-9.4-x86_64.0-install_arabic_language@uefi](https://openqa.rockylinux.org/tests/166476#step/disk_guided_encrypted/3) after which the fixed needle `match` area and `click_point` were added to the existing JSON file.

### PR runs on openQA production system

Rocky 9.4 x86_64 - [rocky-9.4-universal-x86_64-Buildtcooper_os-autoinst-distri-rocky_disk_guided_encrypted_arabic-install_arabic_language@tcooper_os-autoinst-distri-rocky_disk_guided_encrypted_arabic@uefi](https://openqa.rockylinux.org/tests/166759#)

Rocky 9.4 aarch64 - [rocky-9.4-universal-aarch64-Buildtcooper_os-autoinst-distri-rocky_disk_guided_encrypted_arabic-install_arabic_language@tcooper_os-autoinst-distri-rocky_disk_guided_encrypted_arabic@aarch64](https://openqa.rockylinux.org/tests/166761#) 

_NOTE: The aarch64 run gets past disk_guided_encrypted, which this PR addresses, it further passes disk_guided_encrypted_postinstall but fails _graphical_wait_login due to screen blanking during user login causing failure to match needles to complete. The aarch64 worker is non-native and running in emulation mode and issues like this are frequent. I've reposted the test to see if it passes on a second run with a VNC session attached but consider the above linked test pass for this particular issue._