### PR TITLE
DRAFT: restore podman

### DIFF
--- a/templates.fif.json
+++ b/templates.fif.json
@@ -1432,6 +1432,39 @@
                 "USER_LOGIN": "false"
             }
         },
+        "podman": {
+            "profiles": {
+                "rocky-dvd-iso-x86_64-*-uefi": 30
+            },
+            "settings": {
+                "BOOTFROM": "c",
+                "HDD_1": "disk_%FLAVOR%_%MACHINE%.qcow2",
+                "NICTYPE": "tap",
+                "POSTINSTALL": "podman",
+                "POST_STATIC": "172.16.2.114 podman001.test.openqa.rockylinux.org",
+                "ROOT_PASSWORD": "weakpassword",
+                "START_AFTER_TEST": "%DEPLOY_UPLOAD_TEST%",
+                "USER_LOGIN": "false",
+                "WORKER_CLASS": "tap2"
+            }
+        },
+        "podman_client": {
+            "profiles": {
+                "rocky-dvd-iso-x86_64-*-uefi": 30
+            },
+            "settings": {
+                "BOOTFROM": "c",
+                "HDD_1": "disk_%FLAVOR%_%MACHINE%.qcow2",
+                "NICTYPE": "tap",
+                "PARALLEL_WITH": "podman",
+                "POSTINSTALL": "_podman_client",
+                "POST_STATIC": "172.16.2.115 podclient001.test.openqa.rockylinux.org",
+                "ROOT_PASSWORD": "weakpassword",
+                "START_AFTER_TEST": "%DEPLOY_UPLOAD_TEST%",
+                "USER_LOGIN": "false",
+                "WORKER_CLASS": "tap2"
+            }
+        },
         "realmd_join_cockpit": {
             "profiles": {
                 "rocky-dvd-iso-aarch64-*-aarch64": 30,

--- a/tests/podman.pm
+++ b/tests/podman.pm
@@ -14,19 +14,19 @@ sub run {
     # check podman is installed
     assert_script_run "rpm -q podman";
     # check to see if you can pull an image from the registry
-    assert_script_run "podman pull registry.fedoraproject.org/fedora:latest", 300;
+    assert_script_run "podman pull docker.io/rockylinux/rockylinux:9", 300;
     # run hello-world to test
-    validate_script_output "podman run -it registry.fedoraproject.org/fedora:latest echo Hello-World", sub { m/Hello-World/ };
+    validate_script_output "podman run -it docker.io/rockylinux/rockylinux:9 echo Hello-World", sub { m/Hello-World/ };
     # create a Dockerfile
-    assert_script_run 'printf \'FROM registry.fedoraproject.org/fedora:latest\nRUN /usr/bin/dnf install -y httpd\nEXPOSE 80\nCMD ["-D", "FOREGROUND"]\nENTRYPOINT ["/usr/sbin/httpd"]\n\' > Dockerfile';
+    assert_script_run 'printf \'FROM docker.io/rockylinux/rockylinux:9\nRUN /usr/bin/dnf install -y httpd\nEXPOSE 80\nCMD ["-D", "FOREGROUND"]\nENTRYPOINT ["/usr/sbin/httpd"]\n\' > Dockerfile';
     # Build an image
-    assert_script_run 'podman build -t fedora-httpd $(pwd)', 180;
+    assert_script_run 'podman build -t rocky-httpd $(pwd)', 180;
     # Verify the image
-    validate_script_output "podman images", sub { m/fedora-httpd/ };
+    validate_script_output "podman images", sub { m/rocky-httpd/ };
     # Run the container
-    assert_script_run "podman run -d -p 80:80 localhost/fedora-httpd";
+    assert_script_run "podman run -d -p 80:80 localhost/rocky-httpd";
     # Verify the container is running
-    validate_script_output "podman container ls", sub { m/fedora-httpd/ };
+    validate_script_output "podman container ls", sub { m/rocky-httpd/ };
     # Test apache is working
     assert_script_run "curl http://localhost";
     # Open the firewall, except on CoreOS where it's not installed


### PR DESCRIPTION
This DRAFT PR contains initial changes to `templates.fif.json` to restore podman test suite to the Rocky openQA that were removed after initial upstream fork to limit the scope of work to migrate openQA to support Rocky.

While it is useful to compare upstream tests to understand test suite flow care needs to be taken because there may be substantial differences between Rocky 8 and 9 for these tests. I suggest we focus on adding these for Rocky 9 (and shortly 10) and do not spend significant effort making these work for Rocky 8.

Applying this branch to dev openQA instances will allow the needles to be captured and tests modified without increasing the number of failure in the production openQA instance needlessly.