### PR TITLE
fix: do not overwrite the grub wrapper

### DIFF
--- a/tests/_do_install_and_reboot.pm
+++ b/tests/_do_install_and_reboot.pm
@@ -182,7 +182,7 @@ sub run {
         # messages, which screw up some needles
         assert_script_run 'sed -i -e "s,\(GRUB_CMDLINE_LINUX.*\)\",\1 console=tty0 quiet\",g" ' . $mount . '/etc/default/grub';
         # regenerate the bootloader config
-        assert_script_run "chroot $mount grub2-mkconfig -o /boot/efi/EFI/rocky/grub.cfg";
+        assert_script_run "chroot $mount grub2-mkconfig -o /boot/grub2/grub.cfg";
     }
     if (grep { $_ eq 'abrt' } @actions) {
         # Chroot in the newly installed system and switch on ABRT systemwide


### PR DESCRIPTION
During Rocky Linux 9.5 `aarch64` testing the following error prevented all tests from completing successfully. From the `_do_install_and_reboot` test suite after completing installation but before reboot...

```
...
After installation in `aarch64` `GRUB_CMDLINE_LINUX` is modified to add `console=tty0 quiet` using `grub2-mkconfig`. Legacy command generated the following error...

Running `grub2-mkconfig -o /boot/efi/EFI/rocky/grub.cfg' will overwrite the GRUB wrapper.
Please run `grub2-mkconfig -o /boot/grub2/grub.cfg' instead to update grub.cfg.
GRUB configuration file was not updated.
...
```

This PR implements the recommended change and with it made as a `hotfix` the following `aarch64` tests were completed where they previously failed...

- Rocky-9.5-aarch64-boot.iso - `install_default` - https://openqa.rockylinux.org/tests/180070
- Rocky-9.5-aarch64-boot.iso - `install_minimal` - https://openqa.rockylinux.org/tests/180069
- Rocky-9.5-RC1-aarch64-dvd.iso - `install_package_set_graphical_server` - https://openqa.rockylinux.org/tests/180073
- Rocky-9.5-RC1-aarch64-dvd.iso - `install_package_set_minimal` - https://openqa.rockylinux.org/tests/180071
- Rocky-9.5-RC1-aarch64-dvd.iso - `install_package_set_server` - https://openqa.rockylinux.org/tests/180072