### PR TITLE
fix: install_pxeboot needs to run in parallel with support_server

### DIFF
--- a/templates.fif.json
+++ b/templates.fif.json
@@ -1098,15 +1098,14 @@
         "install_pxeboot": {
             "profiles": {
                 "rocky-universal-aarch64-*-aarch64": 30,
-                "rocky-universal-x86_64-*-uefi": 30,
-                "rocky-universal-x86_64-*-bios": 31
+                "rocky-universal-x86_64-*-uefi": 30
             },
             "settings": {
                 "+ISO": "",
                 "DELAYED_START": "1",
                 "KICKSTART": "1",
                 "NICTYPE": "tap",
-                "PARALLEL_WITH": "support_server@bios",
+                "PARALLEL_WITH": "support_server",
                 "PXEBOOT": "once",
                 "ROOT_PASSWORD": "111111",
                 "TEST_TARGET": "COMPOSE",


### PR DESCRIPTION
This PR fixes the issue currently seen where `install_pxeboot` dangles with no support_server test to satisfy it's requirement for running in PARALLEL_WITH="support_server".

Also, currently there is an error reported in the default daily POST...

```
+ openqa-cli api -X POST isos ISO=Rocky-8.10-x86_64-dvd1.iso ARCH=x86_64 DISTRI=rocky FLAVOR=universal LOCATION=https://download.r
ockylinux.org/pub/rocky/8.10 NICTYPE_USER_OPTIONS=net=172.16.2.0/24 QEMU_HOST_IP=172.16.2.2 VERSION=8.10 CURRREL=8 GRUB=ip=dhcp BU
ILD=20241120-Rocky-8.10-x86_64.0
{"count":43,"failed":[{"error_messages":["PARALLEL_WITH=support_server@bios not found - check for dependency typos and dependency cycles"],"job_id":181019},{"error_messages":["PARALLEL_WITH=support_server@bios not found - check for dependency typos and dependency cycles"],"job_id":181028}],"ids":[181016,181017,181018,181020,181021,181022,181023,181024,181025,181026,181027,181029,181030,181031,181032,181033,181034,181035,181036,181037,181038,181039,181040,181041,181042,181043,181044,181045,181046,181047,181048,181049,181050,181051,181052,181053,181054,181055,181056,181057,181058,181059,181060],"scheduled_product_id":9573}
```

...which should also be resolved.

Since changes to `templates.fif.json` require reconfiguration of openQA this cannot be run in the production system and must be run in a development system with multi-host support working to verify completely.

The error output should disappear even if the tests never run due to missing `tap` workers.
