### PR TITLE
maint: update POST scripts for 9.5

### DIFF
--- a/scripts/post_after_upgrade_tests.sh
+++ b/scripts/post_after_upgrade_tests.sh
@@ -3,7 +3,7 @@
 set -x
 
 ARCHES=("x86_64" "aarch64")
-VERSIONS=("8.10" "9.4")
+VERSIONS=("8.10" "9.5")
 ISO_URL_BASE="https://download.rockylinux.org/pub/rocky"
 FACTORY_ISO_FIXED_DIR=/var/tmp/openqa/share/factory/iso/fixed
 

--- a/scripts/post_all_factory.sh
+++ b/scripts/post_all_factory.sh
@@ -3,7 +3,7 @@
 set -x
 
 ARCHES=("x86_64")
-VERSIONS=("8.10" "9.4")
+VERSIONS=("8.10" "9.5")
 ISO_URL_BASE="https://download.rockylinux.org/pub/rocky"
 FACTORY_ISO_FIXED_DIR=/var/tmp/openqa/share/factory/iso/fixed
 

--- a/scripts/post_all_factory_aarch64.sh
+++ b/scripts/post_all_factory_aarch64.sh
@@ -3,7 +3,7 @@
 set -x
 
 ARCHES=("aarch64")
-VERSIONS=("8.10" "9.4")
+VERSIONS=("8.10" "9.5")
 ISO_URL_BASE="https://download.rockylinux.org/pub/rocky"
 FACTORY_ISO_FIXED_DIR=/var/tmp/openqa/share/factory/iso/fixed
 

--- a/scripts/post_cloud_factory.sh
+++ b/scripts/post_cloud_factory.sh
@@ -3,7 +3,7 @@
 set -x
 
 ARCHES=("x86_64")
-VERSIONS=("8.10" "9.4")
+VERSIONS=("8.10" "9.5")
 IMAGE_URL_BASE="https://dl.rockylinux.org/pub/rocky"
 FACTORY_HDD_FIXED_DIR=/var/tmp/openqa/share/factory/hdd/fixed
 

--- a/scripts/post_minimal_factory.sh
+++ b/scripts/post_minimal_factory.sh
@@ -3,7 +3,7 @@
 set -x
 
 ARCHES=("x86_64" "aarch64")
-VERSIONS=("8.10" "9.4")
+VERSIONS=("8.10" "9.5")
 ISO_URL_BASE="https://download.rockylinux.org/pub/rocky"
 FACTORY_ISO_FIXED_DIR=/var/tmp/openqa/share/factory/iso/fixed
 

--- a/scripts/run-all-flavors.sh
+++ b/scripts/run-all-flavors.sh
@@ -6,7 +6,7 @@ set -e
 # Test a beta build with alternative repo URL
 #   ROCKY_EXTRA_ARGS="GRUB=ip=dhcp GRUBADD=inst.repo=https://dl.rockylinux.org/stg/rocky/8.8-BETA/BaseOS/x86_64/os DNF_CONTENTDIR=stg CURRREL=8 IDENTIFICATION=false" scripts/run-all-flavors.sh
 
-ROCKY_VERSION="9.2"
+ROCKY_VERSION="9.5"
 
 MAJOR_VERSION=${ROCKY_VERSION:0:1}
 MINOR_VERSION=${ROCKY_VERSION:2:1}

--- a/scripts/run-openqa-tests.sh
+++ b/scripts/run-openqa-tests.sh
@@ -12,7 +12,7 @@ set -e
 ## Run the localization test suites
 # ROCKY_FLAVOR ROCKY_EXTRA_ARGS=TEST=install_arabic_language,install_asian_language,install_european_language,install_cyrillic_language scripts/run-openqa-tests.sh
 
-ROCKY_VERSION="9.2"
+ROCKY_VERSION="9.5"
 
 MAJOR_VERSION=${ROCKY_VERSION:0:1}
 MINOR_VERSION=${ROCKY_VERSION:2:1}


### PR DESCRIPTION
This PR updates scripts used to POST standard openQA runs to run for Rocky Linux `VERSION=9.5`.