### PR TITLE
Bugfix for server_realmd_join_kickstart

### DIFF
--- a/tests/_boot_to_anaconda.pm
+++ b/tests/_boot_to_anaconda.pm
@@ -90,7 +90,7 @@ sub run {
         # match for the installer bootloader if it hangs around for a
         # while after do_bootloader finishes (in PXE case it does)
         sleep 20;
-        assert_screen "bootloader", 3600;
+        assert_screen "login_screen", 3600;
     }
     else {
         if (get_var("ANACONDA_TEXT")) {


### PR DESCRIPTION
This supersedes #237

In module _boot_to_anaconda.pm line 93 there is a 60 min timeout giving time for the bootloader, install and login sequence to complete. A correction is made here to the needle tag which detects the end of that sequence and thereby allows the server_realmd_join_kickstart test to complete which in turn allows the
server_role_deploy_domain_controller test also to complete.

Tested:
```
openqa-cli api -X POST isos ISO=Rocky-9.5-x86_64-dvd.iso ARCH=x86_64 DISTRI=rocky FLAVOR=dvd-iso VERSION=9.5 CURRREL=9 LOCATION=https://dl.rockylinux.org/pub/rocky/9.5 BUILD=-"$(date +%Y%m%d.%H%M%S).0"-dvd-iso-9.5 TEST=server_realmd_join_kickstart
```

Result:

![Screenshot 2024-11-23 at 16-38-15 openQA Test results](https://github.com/user-attachments/assets/4399e6d2-a479-493a-8f95-e9b7e4b405dd)


