### PR TITLE
Restore Apps - continued

### DIFF
--- a/tests/applications/archiver/aaa_setup.pm
+++ b/tests/applications/archiver/aaa_setup.pm
@@ -1,0 +1,37 @@
+use base "installedtest";
+use strict;
+use testapi;
+use utils;
+
+# This will set up the environment for the archiver test.
+# It creates nine file and places them in the Documents folder.
+# Then opens Nautilus (archive fce) and switches to that folder.
+
+sub run {
+    my $self = shift;
+    my $username = get_var("USER_LOGIN") // "test";
+    # Create the files on the CLI
+    $self->root_console(tty => 3);
+    assert_script_run("cd /home/$username/Documents");
+    assert_script_run('for i in {1..9}; do echo $i > file$i.txt; done');
+    assert_script_run("chown -R $username:$username /home/$username/Documents/");
+    # Exit to the GUI
+    desktop_vt;
+
+    # Set the update notification timestamp
+    set_update_notification_timestamp();
+
+    # Start the application
+    menu_launch_type("nautilus", checkstart => 1, maximize => 1);
+
+    # Open the Documents directory
+    assert_and_click("gnome_open_location_documents");
+}
+
+sub test_flags {
+    return {fatal => 1, milestone => 1};
+}
+
+1;
+
+# vim: set sw=4 et:

--- a/tests/applications/archiver/archive.pm
+++ b/tests/applications/archiver/archive.pm
@@ -1,0 +1,42 @@
+use base "installedtest";
+use strict;
+use testapi;
+use utils;
+
+# This script will test if files in a directory can be archived
+# in an archive file.
+
+sub run {
+    my $self = shift;
+
+    # At first, let us click on one of the icons to get focus
+    # and then use ctrl-a to select all.
+    assert_and_click("archiver_file_one");
+    send_key("ctrl-a");
+    # Right click on the first of them to open the context menu.
+    assert_and_click("archiver_file_one", button => 'right');
+    wait_still_screen(3);
+    # Select to archive it.
+    assert_and_click("archiver_context_archive");
+    # Wait for the screen to appear and settle
+    assert_screen("archiver_format_selector");
+    wait_still_screen 2;
+    # Type the name for the archive
+    type_very_safely("archived_files");
+    # Open the selection of formats.
+    assert_and_click("archiver_format_selector");
+    # Select the tar.xz method
+    assert_and_click("archiver_select_tarxz");
+    # Confirm
+    assert_and_click("archiver_button_create");
+    # Assert that a file has been created in that directory (it may take some time)
+    assert_screen("archiver_archive_created");
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;
+
+# vim: set sw=4 et:

--- a/tests/applications/archiver/extract.pm
+++ b/tests/applications/archiver/extract.pm
@@ -1,0 +1,49 @@
+use base "installedtest";
+use strict;
+use testapi;
+use utils;
+
+# This script will take a newly created archive and will move it into
+# another folder, where it will be extracted and checked.
+
+
+sub run {
+    my $self = shift;
+    my $username = get_var("USER_LOGIN") // "test";
+    # We are already in the correct directory, so let's just
+    # select the newly archived file, that should be there.
+    assert_and_click("archiver_archive_created");
+    send_key("ctrl-x");
+    # Go to the Picture folder.
+    assert_and_click("gnome_open_location_pictures");
+    # Paste it there.
+    send_key("ctrl-v");
+    # Assert that a file has been created in that directory (it may take some time)
+    assert_screen("archiver_archive_created");
+    # Right click onto it
+    click_lastmatch(button => 'right');
+    # Select to Extract the content
+    assert_and_click("archiver_context_extract");
+    # Assert that the extracted folder appeared in that location.
+    assert_screen("archiver_archive_extracted");
+
+    # Go to console for further testing.
+    $self->root_console(tty => 3);
+    # The archive has been removed from the original location.
+    assert_script_run("! ls /home/$username/Documents/archived_files.tar.xz");
+    # The archive has been put into a new location.
+    assert_script_run("ls /home/$username/Pictures/archived_files.tar.xz");
+    # The content was extracted.
+    #assert_script_run("ls /home/$username/Pictures/archived_files");
+    # All nine files are there.
+    validate_script_output("ls /home/$username/Pictures/archived_files/* | wc -l", qr/9/);
+
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;
+
+# vim: set sw=4 et:


### PR DESCRIPTION
Some tests for desktop previously added to templates.fif.json were not implemented in code. This MR will continue where #230 left off by including archiver, characters, contacts,  fonts, gnome-panel, nautilus, loupe and maps.