### PR TITLE
fix: adjust needle width to NOT match server with GUI

### DIFF
--- a/needles/anaconda/package_selection/rocky-anaconda_server_selected-20260312.json
+++ b/needles/anaconda/package_selection/rocky-anaconda_server_selected-20260312.json
@@ -4,7 +4,7 @@
       "xpos": 27,
       "ypos": 130,
       "type": "match",
-      "width": 67,
+      "width": 80,
       "height": 18,
       "match": 90
     }


### PR DESCRIPTION
This MR fixes a needle captured 2026-03-12 for `package-set` that was intended to match `Server` item in the Software Selection panel for Rocky 10+ but also matched `Server with GUI` causing a failure of the `package-set-server` test in `_console_wait_login` because the SUT was installed and booted with `graphical-server-environment`.

The needles match area was simply made wider to include the white space to the right of `Server` keeping all other properties causing it to not match `Server with GUI`.

#### before
<img width="2414" height="2004" alt="rocky10u1-package-set-server-01" src="https://github.com/user-attachments/assets/83b53452-2f0f-4ae0-927a-bbcd1d39e5c5" />

#### after

<img width="2414" height="2004" alt="rocky10u1-package-set-server-02" src="https://github.com/user-attachments/assets/4fbd8421-0ec5-4db1-be60-42abdc5bbca0" />

> NOTE: If the needle match doesn't get picked up by Rocky 10.2+ (which is it's intended use) then it will eventually be removed in a future needle cleanup operation.