### PR TITLE
fix: skip FIPS mode item in GRUB menu in Rocky 9+

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1107,6 +1107,10 @@ sub select_rescue_mode {
     }
     else {
         # select troubleshooting
+        if (get_var("DISTRI") eq "rocky" && (get_version_major() >= 9)) {
+            # Skip FIPS mode item in GRUB menu in Rocky 9+
+            send_key "down";
+        }
         send_key "down";
         send_key "ret";
         # select "rescue system"


### PR DESCRIPTION
Rocky 9+ have an additional item in the Grub2 menu for FIPS that must be skipped to activate the `Troubleshooting->` item for the `install_rescue_encrypted` test.

This MR adds an additional key press to skip over the FIPS entry for Rocky 9+.

---

### Rocky 9.7

#### before
<img width="2414" height="2004" alt="rocky9u7-install-rescue-encrypted-01" src="https://github.com/user-attachments/assets/f01f9aca-3c31-4166-ac5f-c8379c68934b" />

#### after
<img width="2414" height="2004" alt="rocky9u7-install-rescue-encrypted-02" src="https://github.com/user-attachments/assets/7a757a87-bcd6-4b86-b3d6-fe23ef6fe9df" />

---

### Rocky 10.1

#### before
<img width="2414" height="2004" alt="rocky10u1-install-rescue-encrypted-01" src="https://github.com/user-attachments/assets/8b2d07c7-ab45-4c79-aab6-f5d348eea192" />

#### after
<img width="2414" height="2004" alt="rocky10u1-install-rescue-encrypted-02" src="https://github.com/user-attachments/assets/f8ff3383-0c8b-49ea-9cc3-b210f89a0d03" />
