### PR TITLE
fix: flatpak match appears to be case sensitive in Rocky 10+

### DIFF
--- a/tests/applications/weather/aaa_setup.pm
+++ b/tests/applications/weather/aaa_setup.pm
@@ -13,7 +13,7 @@ sub run {
     # NOTE: This will trigger an authentication (perhaps 2x) in desktop_vt()
     $self->root_console(tty => 3);
     assert_script_run("flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo");
-    assert_script_run "flatpak install -y flathub org.gnome.weather",300;
+    assert_script_run "flatpak install -y flathub org.gnome.Weather", 300;
 
     # Exit the terminal
     desktop_vt;
@@ -64,4 +64,3 @@ sub test_flags {
 1;
 
 # vim: set sw=4 et:
-


### PR DESCRIPTION
This MR modifies `aaa_setup.pm` when installing the Gnome Weather app flatpak to install using cased name of the flatpak. The lower case name appears to work with Rocky 9+ but the upper case name is required in Rocky 10+ and has no ill effects for Rocky 9+.

---

#### before
<img width="2414" height="2346" alt="rocky10u1-flatpak-install-weather-01" src="https://github.com/user-attachments/assets/cbc23722-eb50-46af-8111-3e50493f94ed" />

#### after
<img width="2414" height="2346" alt="rocky10u1-flatpak-install-weather-02" src="https://github.com/user-attachments/assets/1a797343-b689-43ac-b833-dc21b460724a" />
